### PR TITLE
testing, issue #157 : set up no estimation model runs for each commit

### DIFF
--- a/.github/workflows/run-no-est.yml
+++ b/.github/workflows/run-no-est.yml
@@ -1,44 +1,75 @@
 # run models without estimation
 name: run-no-est
-on: [workflow_dispatch]
+on: [push, pull_request]
+
 jobs:
   run-no-est:
     runs-on: ubuntu-latest
-    container: 
-      image: rocker/r-ver
+    env:
+      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
+
     steps:
-    
+
       - name: Checkout ss repo
         uses: actions/checkout@v2
         
-      - name: print dir
-        run: pwd
-        
-      - name: Get last compiled version of SS
-        uses: dawidd6/action-download-artifact@v2
-        with: 
-          workflow: build-centos.yml
-          workflow_conclusion: success
-          steps:
-          name: ss_linux
-          path: ss_linux
-     
-      - name: see file names
-        run: ls
+ #     - name: Get last compiled version of SS; alternative to compiling in same wkflow
+ #       uses: dawidd6/action-download-artifact@v2
+ #       with: 
+ #         workflow: build-centos.yml
+ #         workflow_conclusion: success
+ #         name: ss_linux
+ #         path: ss_linux
           
       - name: Checkout models repo
         uses: actions/checkout@v2
         with:
-          repository: 'stock-synthesis/ss-test-models'
+          repository: 'nmfs-stock-synthesis/ss-test-models'
           path: ss-test-models-repo
           
-      - name: see file names
-        run: ls
+      - name: setup R  
+        uses: r-lib/actions/setup-r@master
+      
+      - name: Get admb and put in path
+        run: |
+          wget https://github.com/admb-project/admb/releases/download/admb-12.3/admb-12.3-linux.zip
+          sudo unzip admb-12.3-linux.zip -d /usr/local/bin
+          sudo chmod 755 /usr/local/bin/admb-12.3/bin/admb
+          echo "/usr/local/bin/admb-12.3/bin" >> $GITHUB_PATH
+          
+      - name: Build stock synthesis
+        run: |
+          rm -rf SS330
+          mkdir SS330
+          /bin/bash ./Make_SS_330_new.sh -b SS330
+
+      - name: move exes, scripts to needed locations
+        run: |
+          mv ss-test-models-repo/models ss-test-models-repo/model_runs
+          mv SS330/ss ss-test-models-repo/model_runs/ss
+          mv ss-test-models-repo/jenkins/model_compare_noest/run_from_par.R ss-test-models-repo/run_from_par.R
+          mv ss-test-models-repo/jenkins/model_compare_noest/run_compare_noest.R ss-test-models-repo/run_compare_noest.R
+          
+      - name: change permissions on ss exes
+        run: chmod a+x ss-test-models-repo/model_runs/ss
+      
+      - name: run models without estimation
+        run: |
+         cd ss-test-models-repo && Rscript run_from_par.R
         
-      - uses: r-lib/actions/setup-r@master
-#      - name: unpack ss exe
-#      - name: move scripts to needed locations
-#      - name: run models with no estimation
-#      - name: do comparison
-#      - name: Fail or pass job
-#      - name: save artifacts, maybe?
+      - name: Run comparison
+        run: |
+          mkdir ss-test-models-repo/run_R
+          cd ss-test-models-repo && Rscript run_compare_noest.R
+          
+      - name: Determine results of test
+        run: cd ss-test-models-repo && Rscript jenkins/shared/check_failed.R
+      
+      - name: Archive results
+        uses: actions/upload-artifact@main
+        if: always()
+        with:
+          name: 'result_textfiles'
+          path: ss-test-models-repo/run_R/
+          


### PR DESCRIPTION
This adds a new check on every commit to SS (we can change this frequency if it seems like too much ) where the ss-test-models are run with no estimation and checked if the values are the same or different as in the reference model. Hopefully this will catch changes that impact calculations in the SS code base more quickly.

@Rick-Methot-NOAA , if the checks pass and this description of how this works makes sense to you, please feel free to merge this in! Note it will only be available in main after merging, so if we want to use it in other branches we will need to manually create it (which I can do).