### PR TITLE
Add compiler warning gh action to main branch

### DIFF
--- a/.github/workflows/build-warnings.yml
+++ b/.github/workflows/build-warnings.yml
@@ -38,5 +38,5 @@ jobs:
           rm -rf SS330
           rm -rf ss_linux.tar
           mkdir SS330
-          /bin/bash ./Make_SS_330_new.sh -b SS330 -w
+          /bin/bash ./Make_SS_330_new.sh -a /usr/local/bin/admb-12.3 -b SS330 -w
           

--- a/.github/workflows/build-warnings.yml
+++ b/.github/workflows/build-warnings.yml
@@ -22,12 +22,6 @@ jobs:
       - name: Checkout ss repo
         uses: actions/checkout@v2
           
-      - name: Checkout models repo
-        uses: actions/checkout@v2
-        with:
-          repository: 'nmfs-stock-synthesis/ss-test-models'
-          path: ss-test-models-repo
-          
       - name: setup R  
         uses: r-lib/actions/setup-r@master
       

--- a/.github/workflows/build-warnings.yml
+++ b/.github/workflows/build-warnings.yml
@@ -1,30 +1,36 @@
 name: build-warnings
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the main branch
-on: [workflow_dispatch]
-
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+# Controls when the action will run.
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+      
 jobs:
   build-warnings:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-18.04
-    # Limit run time to 15 min to avoid wasting action minutes.
-    timeout-minutes: 15
-    container: 
-      image: centos:7.9.2009
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+    runs-on: ubuntu-latest
+    env:
+      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
 
-      - name: Get essential tools needed on docker
-        run: |
-         yum -y update && yum clean all
-         yum -y install wget
-         yum install -y zip unzip
-         yum install -y sudo
-         yum install -y gcc-c++
+    steps:
+
+      - name: Checkout ss repo
+        uses: actions/checkout@v2
+          
+      - name: Checkout models repo
+        uses: actions/checkout@v2
+        with:
+          repository: 'nmfs-stock-synthesis/ss-test-models'
+          path: ss-test-models-repo
+          
+      - name: setup R  
+        uses: r-lib/actions/setup-r@master
+      
       - name: Get admb and put in path
         run: |
           wget https://github.com/admb-project/admb/releases/download/admb-12.3/admb-12.3-linux.zip
@@ -32,11 +38,52 @@ jobs:
           sudo chmod 755 /usr/local/bin/admb-12.3/bin/admb
           echo "/usr/local/bin/admb-12.3/bin" >> $GITHUB_PATH
           
-      # Runs a set of commands using the runners shell
       - name: Build stock synthesis with warnings
         run: |
           rm -rf SS330
-          rm -rf ss_linux.tar
           mkdir SS330
-          /bin/bash ./Make_SS_330_new.sh -a /usr/local/bin/admb-12.3 -b SS330 -w
+          /bin/bash ./Make_SS_330_new.sh -a /usr/local/bin/admb-12.3 -b SS330 -w &> warnings.txt
+      # Runs a set of commands using the runners shell
+      - name: Use R to parse warnings output
+        run: |
+          txt <- readLines("warnings.txt", encoding = "UTF-8" )
+          warn_line <- grep(pattern = "compiling a second time to get warnings",
+            x = txt, 
+            fixed = TRUE)
+          txt <- txt[(warn_line+1):length(txt)]
+          rm_warn_start_lines <- grep(pattern = "/usr/local/bin/admb-12.3", x = txt, 
+            fixed = TRUE)
+          all_warning_end_lines <- grep(pattern = "^", x = txt, fixed = TRUE)
+          to_rm <- NULL
+          for (l in rm_warn_start_lines) {
+            tmp_end_line <- min(all_warning_end_lines[all_warning_end_lines > l])
+            to_rm <- c(to_rm, l:tmp_end_line)
+          } 
+          txt <- txt[-to_rm]
+          n_errors <- length(grep(pattern = "^", x = txt, fixed = TRUE))
+          message("There are ", n_errors, " warning messages related to SS.")
+          write.table(n_errors, "n_warn.txt")
+          writeLines(txt, "warnings_ss.txt")
+        shell: Rscript {0}
+        
+      - name:  Print warnings
+        run: cat warnings_ss.txt
+        
+      - name: determine if fails/passes
+        run: |
+          n_warn <- read.table("n_warn.txt")
+          n_warn <- as.integer(n_warn[1,1])
+          if (n_warn > 80) {
+            stop("Increased number of warnings")
+          } else {
+            message("Acceptable number of warnings")
+          } 
+        shell: Rscript {0}
+        
+      - name: Archive warnings text file
+        if: always()
+        uses: actions/upload-artifact@main
+        with:
+          name: 'warnings_ss.txt'
+          path: warnings_ss.txt
           

--- a/Make_SS_330_new.sh
+++ b/Make_SS_330_new.sh
@@ -147,7 +147,7 @@ chmod a+x $BUILD_TYPE
 # output warnings
 if [[ "$WARNINGS" == "on" ]] ; then
     echo "... compiling a second time to get warnings ..."
-    g++ -c -std=c++0x -O3 -I. -I"$ADMB_HOME/include" -I"/$ADMB_HOME/contrib/include" -o$BUILD_TYPE.obj $BUILD_TYPE.cpp -Wall -Wextra
+    g++ -c -std=c++0x -O3 -I. -I"$ADMB_HOME/include" -I"/$ADMB_HOME/include/contrib" -o$BUILD_TYPE.obj $BUILD_TYPE.cpp -Wall -Wextra
 fi
 
 


### PR DESCRIPTION
This addresses #131 . It will warn if there are more warnings than 80, which was the current number of warnings (in the gh_actions_warn branch, at least, not yet sure if the number will need to be adjusted for main) and will create a text file of warning related to SS as an archive. There will probably be some changes we want to make, but I think it can provide value and should be merged into main.

