### PR TITLE
test, # 170, #142: add run-with-est job

### DIFF
--- a/.github/workflows/run-with-est.yml
+++ b/.github/workflows/run-with-est.yml
@@ -1,6 +1,13 @@
 # run fast running SS models with estimation
 name: run-with-est
-on: [workflow_dispatch]
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   run-with-est:
@@ -40,21 +47,20 @@ jobs:
         run: |
           mv ss-test-models-repo/models ss-test-models-repo/model_runs
           mv SS330/ss ss-test-models-repo/model_runs/ss
-          mv ss-test-models-repo/jenkins/model/run_models.sh ss-test-models-repo/run_models.sh
-          mv ss-test-models-repo/jenkins/compare/rename_ref_files.sh ss-test-models-repo/rename_ref_files.sh
-          mv ss-test-models-repo/jenkins/compare/run_compare.R ss-test-models-repo/run_compare.R
-      
+  
       - name: keep only fast running models
         run: |
-          keep_mods <- c("growth_timevary", "Hake_2018", "Hake_2019_semi-parametric_selex", 
+          # comment out some temporarily for testing.
+          keep_mods <- c("growth_timevary", "Hake_2018", "growth_morphs", "Hake_2019_semi-parametric_selex", 
             "Empirical_Wtatage_Age_Selex", "Simple_NoCPUE", "Simple", "Simple_with_Discard",
             "tagging_mirrored_sel", "three_area_nomove", "vermillion_snapper", "three_area",
-            "growth_morphs", "KelpGreenling2015", BigSkate_2019")
-          all_mods <- list.dirs(file.path("ss-test-models-repo", "model_runs"), full_names = FALSE, recursive = FALSE)
+            "KelpGreenling2015", "BigSkate_2019")
+            message("Models to keep are ", paste0(keep_mods, collapse = ", " ))
+          all_mods <- list.dirs(file.path("ss-test-models-repo", "model_runs"), full.names = FALSE, recursive = FALSE)
           rm_mods <- all_mods[!all_mods %in% keep_mods]
-          # remove files for models that are not in 
+          # remove files for models that are not in keep_mods
           for (i in rm_mods) {
-            tmp_rm_files <- list.files(file.path("ss-test-models-repo", "model_runs", i), full_names = TRUE)
+            tmp_rm_files <- list.files(file.path("ss-test-models-repo", "model_runs", i), full.names = TRUE)
             file.remove(tmp_rm_files) #rm files
             file.remove(file.path("ss-test-models-repo", "model_runs", i)) #rm dir
           }
@@ -65,12 +71,102 @@ jobs:
       
       - name: run models
         run: |
-         cd ss-test-models-repo && run_models.sh
+          mod_names <- list.dirs(file.path("ss-test-models-repo", "model_runs"), full.names = FALSE, recursive = FALSE)
+          mod_paths <- list.dirs(file.path("ss-test-models-repo", "model_runs"), full.names = TRUE, recursive = FALSE)
+          print(mod_names)
+          run_ss <- function(dir) {
+            wd <- getwd()
+            print(wd)
+            on.exit(system(paste0("cd ", wd)))
+            # rename the reference files 
+            file.rename(file.path(dir, "ss_summary.sso"),
+                        file.path(dir, "ss_summary_ref.sso"))
+            file.rename(file.path(dir, "warning.sso"),
+                        file.path(dir, "warning_ref.sso"))
+            file.copy(file.path(dir, "ss.par"), file.path(dir, "ss_ref.par"))
+            # run the models with estimation and see if model finishes without error
+            message("running ss on ", basename(dir))
+            system(paste0("cd ", dir, " && ../ss -nox"))
+            model_ran <- file.exists(file.path(dir, "control.ss_new"))
+            return(model_ran)
+          }
+
+          mod_ran <- lapply(mod_paths, function(x) tryCatch(run_ss(x), 
+                                                   error = function(e) print(e)
+                                                   ))
+          mod_errors <- mod_names[unlist(lapply(mod_ran, function(x) "simpleError" %in% class(x)))]
+          success <- TRUE
+          if(length(mod_errors) > 0) {
+            message("Model code with errors were: ", paste0(mod_errors, collapse = ", "), 
+                    ". See error list above for more details.")
+            success <- FALSE
+          } else {
+            message("All code ran without error, but model runs may still have failed.")
+          }
+          mod_no_run <- mod_names[unlist(lapply(mod_ran, function(x) isFALSE(x)))] # false means model didn't run
+          if(length(mod_no_run) > 0) {
+            message("Models that didn't run are ", paste0(mod_no_run, collapse = ", "))
+            success <- FALSE
+          } else {
+            message("All models ran without error.")
+          }
+          # determine if job fails or passes
+          if(success == FALSE) {
+            stop("Job failed due to code with errors or models that didn't run.")
+          } else {
+            message("All models successfully ran.")
+          }
+        shell: Rscript {0}
         
       - name: Run comparison
         run: |
-          mkdir ss-test-models-repo/run_R
-          cd ss-test-models-repo && Rscript run_compare.R
+          source("ss-test-models-repo/jenkins/shared/compare.R")
+          orig_wd <- getwd()
+          setwd("ss-test-models-repo")
+          on.exit(orig_wd)
+          dir.create("run_R")
+          # get model folder names
+          mod_fold <- file.path("model_runs")
+          mod_names <- list.dirs(mod_fold, full.names = FALSE, recursive = FALSE)
+          message("Will compare ref runs to new results for these models:")
+          print(mod_names)
+          message("Notable changes in total likelihood, max gradients, ",
+                  " and number of warnings:")
+          compare_list <- vector(mode = "list", length = length(mod_names))
+          for(i in mod_names) {
+            pos <- which(mod_names == i)
+            sum_file <- file.path(mod_fold, i, "ss_summary.sso")
+            ref_sum_file <- file.path(mod_fold, i, "ss_summary_ref.sso")
+          
+            par_file <- file.path(mod_fold, i, "ss.par")
+            ref_par_file <- file.path(mod_fold, i, "ss_ref.par")
+          
+            warn_file <- file.path(mod_fold, i, "warning.sso")
+            ref_warn_file <- file.path(mod_fold, i, "warning_ref.sso")
+          
+            fail_file <- file.path("run_R", "test_failed.csv")
+          
+            compare_list[[pos]] <- compare_ss_runs(mod_name = i, 
+                          sum_file = sum_file, ref_sum_file = ref_sum_file,
+                          par_file = par_file, ref_par_file = ref_par_file, 
+                          warn_file = warn_file, ref_warn_file = ref_warn_file,
+                          hessian = TRUE,
+                          new_file = NULL, fail_file = fail_file)
+          }
+          # write out all model results
+          compare_df <- do.call("rbind", compare_list)
+          compare_df_print <- format(compare_df, digits = 6, nsmall = 3,
+                                   justify = "left")
+          message("see saved artifact all_results.csv for all compared values and their differences.")
+          # write all model comparison results to csv
+          write.csv(compare_df_print, "run_R/all_results.csv", row.names = FALSE)
+          # write all 
+          message("see saved artifact all_changes.csv for only changed values (even if the threshold was too low to fail the job)")
+          filtered_df <- compare_df[compare_df$diff != 0, ]
+          filtered_df <- format(filtered_df, digits = 6, nsmall = 3,
+                                   justify = "left")
+          write.csv(filtered_df, "run_R/all_changes.csv", row.names = FALSE)
+        shell: Rscript {0}
           
       - name: Determine results of test
         run: cd ss-test-models-repo && Rscript jenkins/shared/check_failed.R


### PR DESCRIPTION
Adds a new run-with-est job. See issue #170 (and #142) for more details.

Note that the  job will fail because some models (growth_morphs, Big_Skate) were not passing on the main branch. Vermillion is flagged as failing because a smaller likelihood was found; this issue will be addressed in https://github.com/nmfs-stock-synthesis/ss-test-models/issues/8

I requested @iantaylor-NOAA to review; Ian, I know you have been dabbling a bit in github actions, so thought it might be possible for you to take a look? No worries if not, though.

@Rick-Methot-NOAA , maybe you could comment on if/when it is ok for this to be merged in? I know you have been making changes to SS, which should not conflict with anything in this PR, but feel free to let me know if we need to hold off on merging this for some reason.