### PR TITLE
finish fix for combined age-length selex

### DIFF
--- a/SS_objfunc.tpl
+++ b/SS_objfunc.tpl
@@ -1045,6 +1045,7 @@ FUNCTION void Process_STDquant()
 
 //  SS_Label_7.8  get extra std quantities
     // selectivity
+    //  f = Do_Selex_Std
     if(Selex_Std_Cnt>0)
     {
       for (i=1;i<=Selex_Std_Cnt;i++)
@@ -1062,9 +1063,17 @@ FUNCTION void Process_STDquant()
         }
         else if(Selex_Std_AL==3)
         {
-//  need to re-write this section to reference    save_sel_fec(t,g,f)
-//          Extra_Std(i)=sel_al_3(Selex_Std_Year,Do_Selex_Std,1,j);
-//          if(gender==2) Extra_Std(i+Selex_Std_Cnt)=sel_al_3(Selex_Std_Year,Do_Selex_Std,2,j);
+//  4darray sel_al_3(1,nseas,1,gmorph,1,Nfleet,0,nages);  // selected numbers
+//  4darray save_sel_fec(styr-3*nseas,TimeMax_Fcast_std+nseas,1,gmorph,0,Nfleet,0,nages)  //  save sel_al_3 (Asel_2) and save fecundity for output;  +nseas covers no forecast setups
+
+          int t_write=styr+(Selex_Std_Year-styr)*nseas;  //  season 1 of selected year
+          g=g_Start(1)+N_platoon; //  mid morph for first GP for females
+          Extra_Std(i)=save_sel_fec(t_write,g,Do_Selex_Std,j);
+          if(gender==2)
+            {
+              g=g_Start(1+N_GP)+N_platoon; //  mid morph for first GP for males
+              Extra_Std(i+Selex_Std_Cnt)=save_sel_fec(t_write,g,Do_Selex_Std,j);
+            }
         }
       }
     }

--- a/SS_readcontrol_330.tpl
+++ b/SS_readcontrol_330.tpl
@@ -4440,12 +4440,16 @@
       if(Selex_Std_AL==1) // length-based selex
       {
         if(Selex_Std_Pick(i)<=0) Selex_Std_Pick(i)=1;
-        if(Selex_Std_Pick(i)>nlength) Selex_Std_Pick(i)=nlength;
+        if(Selex_Std_Pick(i)>nlength) {
+          N_warn++; warning<<N_warn<<" Selex_std requested output past nlength, resets to nlength, may produce duplicates"<<endl;
+          Selex_Std_Pick(i)=nlength;}
       }
       else // age-based or age-length-combined selex
       {
         if(Selex_Std_Pick(i)<0) Selex_Std_Pick(i)=0;
-        if(Selex_Std_Pick(i)>nages) Selex_Std_Pick(i)=nages;
+        if(Selex_Std_Pick(i)>nages) {
+          N_warn++; warning<<N_warn<<" Selex_std requested output past nages, resets to nages, may produce duplicates"<<endl;
+          Selex_Std_Pick(i)=nages;}
       }
     }
     // increment count

--- a/SS_readcontrol_330.tpl
+++ b/SS_readcontrol_330.tpl
@@ -4310,6 +4310,7 @@
   More_Std_Input.initialize();
   if(Do_More_Std>0)
   {
+    echoinput<<"inpt_as_read: "<<temp_std_input<<endl;
     More_Std_Input(1,More_Std_N_Inputs) = temp_std_input(1,More_Std_N_Inputs);
     echoinput<<More_Std_Input(1,4)<<" # Selectivity: (1) 0 to skip or fleet, (2) 1=len/2=age/3=combined, (3) year, (4) N selex bins; NOTE: combined reports in age bins"<<endl;
     echoinput<<More_Std_Input(5,6)<<" # Growth: (1) 0 to skip or growth pattern, (2) growth ages; NOTE: does each sex"<<endl;
@@ -5243,12 +5244,11 @@
         }
         else if(Selex_Std_AL==3)
         {
-            N_warn++; cout<<" EXIT - see warning "<<endl;  warning<<N_warn<<" "<<" stderr on combined length-age selectivity is under repair "<<endl; exit(1);
           if(Selex_Std_Pick(i)>nages)
           {
             N_warn++; cout<<" EXIT - see warning "<<endl;  warning<<N_warn<<" "<<" cannot select stdev for age bin greater than maxage "<<Selex_Std_Pick(i)<<" > "<<nages<<endl; exit(1);
           }
-          ParmLabel+="AgeLenSelex_std_"+NumLbl(Do_Selex_Std)+"_"+GenderLbl(g)+"_A_"+NumLbl0(age_vector(Selex_Std_Pick(i))+1)+CRLF(1);
+          ParmLabel+="AgeLenSelex_std_"+NumLbl(Do_Selex_Std)+"_GP1_"+GenderLbl(g)+"_A_"+NumLbl0(age_vector(Selex_Std_Pick(i))+1)+CRLF(1);
         }
       }
     }


### PR DESCRIPTION
Kelli,
Please check that the se for combined age-length selectivity seems reasonable.  I tried the simple example after increasing N platoons to 5 (just to test the indexing) and I get this:
AgeLenSelex_std_1_GP1_Fem_A_0 0.00529027 0.000715725
AgeLenSelex_std_1_GP1_Fem_A_1 0.0171669 0.00210697
AgeLenSelex_std_1_GP1_Fem_A_2 0.0503977 0.00558243
AgeLenSelex_std_1_GP1_Fem_A_3 0.127717 0.0127583
AgeLenSelex_std_1_GP1_Fem_A_4 0.260027 0.0234945
AgeLenSelex_std_1_GP1_Fem_A_5 0.410182 0.0337065
AgeLenSelex_std_1_GP1_Fem_A_6 0.526735 0.0396442
AgeLenSelex_std_1_GP1_Fem_A_7 0.59982 0.0416719
AgeLenSelex_std_1_GP1_Fem_A_8 0.644169 0.0416408
AgeLenSelex_std_1_GP1_Fem_A_9 0.673059 0.0407983
AgeLenSelex_std_1_GP1_Fem_A_10 0.693696 0.0397205
AgeLenSelex_std_1_GP1_Fem_A_11 0.709521 0.0386378
Thanks,
Rick