### PR TITLE
build, issue #202: update gh actions build to automate version numbering

### DIFF
--- a/.github/workflows/build-centos.yml
+++ b/.github/workflows/build-centos.yml
@@ -1,8 +1,12 @@
 name: build-centos
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the main branch
-on: [workflow_dispatch]
+# on: Controls when the action will run. workflow_dispatch is a manual trigger.
+# This workflow also runs when a tag begining with v is pushed.
+on: 
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -12,11 +16,9 @@ jobs:
     # Limit run time to 15 min to avoid wasting action minutes.
     timeout-minutes: 15
     container: 
-      image: centos:7.9.2009
+      image: centos:8.3.2011
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
 
       - name: Get essential tools needed on docker
         run: |
@@ -25,12 +27,117 @@ jobs:
          yum install -y zip unzip
          yum install -y sudo
          yum install -y gcc-c++
+         yum install -y git
+         
+      - name: see git version
+        run: git --version
+         
+      - uses: actions/checkout@v2
+      
+      - name: install R
+        run: |
+          dnf install -y epel-release
+          yum install -y dnf-plugins-core
+          dnf install -y 'dnf-command(config-manager)'
+          dnf config-manager --set-enabled powertools
+          yum install -y  R
+        
       - name: Get admb and put in path
         run: |
           wget https://github.com/admb-project/admb/releases/download/admb-12.3/admb-12.3-linux.zip
           sudo unzip admb-12.3-linux.zip -d /usr/local/bin
           sudo chmod 755 /usr/local/bin/admb-12.3/bin/admb
           echo "/usr/local/bin/admb-12.3/bin" >> $GITHUB_PATH
+        
+      - name: Fetch tags
+        run: |
+          git fetch --tags
+          git fetch --prune --unshallow || true
+          
+      - name: Get the last tag
+        id: get-latest-tag
+        run: |
+          git tag
+          latest_tag=$(git describe --abbrev=0 --tags)
+          latest_tag_commit=$(git rev-list -n 1 $latest_tag)
+          latest_commit=$(git rev-list HEAD -n 1)
+          echo "::set-output name=tag::${latest_tag}"
+          echo "::set-output name=tag_commit::${latest_tag_commit}"
+          echo "::set-output name=commit::${latest_commit}"
+
+       # uses: actions-ecosystem/action-get-latest-tag@v1 # for linux
+       
+        
+      - name: pull the last tag value to use in the Rscript
+        id: get-version
+        run: |
+          echo "${{ steps.get-latest-tag.outputs.tag }}" > .github/last_tag.txt
+          echo "${{ steps.get-latest-tag.outputs.tag_commit }}" > .github/last_tag_commit.txt
+          echo "${{ steps.get-latest-tag.outputs.commit }}" >  .github/last_commit.txt
+
+      - name: Edit the version info for safe version using R code
+        run: |
+          # Get the version
+          # get the last tag from the repository
+          tag_label <- readLines(".github/last_tag.txt")
+          # get commits from from the repository
+          tag_commit <- readLines(".github/last_tag_commit.txt")
+          last_commit <- readLines(".github/last_commit.txt")
+          message("The tag_label is ", tag_label)
+          if (substr(tag_label, start = 1, stop = 6) == "v3.30.") {
+            ver_num_full <- strsplit(tag_label, split = "v3.30", fixed = TRUE)[[1]][2]
+            ver_num <- strsplit(ver_num_full, split = ".", fixed = TRUE)[[1]][2]
+            if(length(grep("-", ver_num)) > 0) {
+              ver_num <- strsplit(ver_num, split = "-", fixed = TRUE)[[1]][1]
+            }
+          } else {
+            ver_num <- "unknown"
+          }
+          message("tag commit: ", tag_commit)
+          message("last  commit: ", last_commit)
+          if(tag_commit == last_commit) {
+            # figure out the version using the tag
+            if(ver_num == "unknown") {
+            fix_ver_num <- "unknown"
+            } else {
+              ver_num_full_split <- strsplit(ver_num_full, split = ".", fixed = TRUE)[[1]]
+              if(length(ver_num_full_split) == 3) {
+                fix_ver_num <- ver_num_full_split[3]
+              } else if(length(ver_num_full_split) == 2) {
+                if(length(grep("-", ver_num_full_split, fixed = TRUE)) > 0) {
+                  fix_ver_num <- strsplit(ver_num_full_split[2], split = "-", fixed = TRUE)[[1]][2]
+                  fix_ver_num <- paste0("00-", fix_ver_num)
+                } else {
+                  fix_ver_num <- "00"
+                }
+              } else {
+                fix_ver_num <- "unknown"
+              }
+            }
+          } else {
+           fix_ver_num <- "beta: not an official version of SS"
+          }
+          message("The minor version label is ", ver_num)
+          message("The patch version label is ", fix_ver_num)
+          
+          # add version numbers to files
+          # safe file
+          ver_info <- readLines("SS_versioninfo_330safe.tpl")
+          ver_info_start <- grep('Create string with version info', ver_info, fixed = TRUE)
+          ver_info[ver_info_start + 1] <-
+            gsub('\\.xx', paste0('\\.', ver_num), ver_info[ver_info_start + 1])
+          ver_info[ver_info_start + 1] <-
+            gsub('\\.yy', paste0('\\.', fix_ver_num), ver_info[ver_info_start+1])
+          writeLines(ver_info, "SS_versioninfo_330safe.tpl")
+          #opt file         
+          ver_info <- readLines("SS_versioninfo_330opt.tpl")
+          ver_info_start <- grep('Create string with version info', ver_info, fixed = TRUE)
+          ver_info[ver_info_start + 1] <-
+            gsub('\\.xx', paste0('\\.', ver_num), ver_info[ver_info_start + 1])
+          ver_info[ver_info_start + 1] <-
+            gsub('\\.yy', paste0('\\.', fix_ver_num), ver_info[ver_info_start+1])
+          writeLines(ver_info, "SS_versioninfo_330opt.tpl")
+        shell: Rscript {0}
           
       # Runs a set of commands using the runners shell
       - name: Build stock synthesis
@@ -46,10 +153,12 @@ jobs:
           sha256sum SS330/ss
           sha256sum SS330/ss_opt
 
-      - name: Delete unneeded files
+      - name: Delete unneeded files and change exe names
         run: |
           cd SS330
           rm *.obj *.htp *.cpp ss_opt.tpl
+          mv ss ss_linux
+          mv ss_opt ss_opt_linux
           
       - name: Archive the exes as tar.
         if: success()

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -1,7 +1,12 @@
 name: build-mac
 
 # on: Controls when the action will run. workflow_dispatch is a manual trigger.
-on: [workflow_dispatch]
+# This workflow also runs when a tag begining with v is pushed.
+on: 
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
 
 jobs:
   build-mac:
@@ -18,6 +23,100 @@ jobs:
           unzip admb-12.3.zip -d /usr/local/bin
           ls /usr/local/bin
           echo "/usr/local/bin/admb-12.3/bin" >> $GITHUB_PATH
+      - name: Set up R
+        uses: r-lib/actions/setup-r@master
+        with:
+          r-version: 'release'
+      
+      - name: Fetch tags
+        run: |
+          git fetch --tags
+          git fetch --prune --unshallow || true
+          
+      - name: Get the last tag
+        id: get-latest-tag
+        run: |
+          git tag
+          latest_tag=$(git describe --abbrev=0 --tags)
+          latest_tag_commit=$(git rev-list -n 1 $latest_tag)
+          latest_commit=$(git rev-list HEAD -n 1)
+          echo "::set-output name=tag::${latest_tag}"
+          echo "::set-output name=tag_commit::${latest_tag_commit}"
+          echo "::set-output name=commit::${latest_commit}"
+
+       # uses: actions-ecosystem/action-get-latest-tag@v1 # for linux
+       
+        
+      - name: pull the last tag value to use in the Rscript
+        id: get-version
+        run: |
+          echo "${{ steps.get-latest-tag.outputs.tag }}" > .github/last_tag.txt
+          echo "${{ steps.get-latest-tag.outputs.tag_commit }}" > .github/last_tag_commit.txt
+          echo "${{ steps.get-latest-tag.outputs.commit }}" >  .github/last_commit.txt
+
+      - name: Edit the version info for safe version using R code
+        run: |
+          # Get the version
+          # get the last tag from the repository
+          tag_label <- readLines(".github/last_tag.txt")
+          # get commits from from the repository
+          tag_commit <- readLines(".github/last_tag_commit.txt")
+          last_commit <- readLines(".github/last_commit.txt")
+          message("The tag_label is ", tag_label)
+          if (substr(tag_label, start = 1, stop = 6) == "v3.30.") {
+            ver_num_full <- strsplit(tag_label, split = "v3.30", fixed = TRUE)[[1]][2]
+            ver_num <- strsplit(ver_num_full, split = ".", fixed = TRUE)[[1]][2]
+            if(length(grep("-", ver_num)) > 0) {
+              ver_num <- strsplit(ver_num, split = "-", fixed = TRUE)[[1]][1]
+            }
+          } else {
+            ver_num <- "unknown"
+          }
+          message("tag commit: ", tag_commit)
+          message("last  commit: ", last_commit)
+          if(tag_commit == last_commit) {
+            # figure out the version using the tag
+            if(ver_num == "unknown") {
+            fix_ver_num <- "unknown"
+            } else {
+              ver_num_full_split <- strsplit(ver_num_full, split = ".", fixed = TRUE)[[1]]
+              if(length(ver_num_full_split) == 3) {
+                fix_ver_num <- ver_num_full_split[3]
+              } else if(length(ver_num_full_split) == 2) {
+                if(length(grep("-", ver_num_full_split, fixed = TRUE)) > 0) {
+                  fix_ver_num <- strsplit(ver_num_full_split[2], split = "-", fixed = TRUE)[[1]][2]
+                  fix_ver_num <- paste0("00-", fix_ver_num)
+                } else {
+                  fix_ver_num <- "00"
+                }
+              } else {
+                fix_ver_num <- "unknown"
+              }
+            }
+          } else {
+           fix_ver_num <- "beta: not an official version of SS"
+          }
+          message("The minor version label is ", ver_num)
+          message("The patch version label is ", fix_ver_num)
+          
+          # add version numbers to files
+          # safe file
+          ver_info <- readLines("SS_versioninfo_330safe.tpl")
+          ver_info_start <- grep('Create string with version info', ver_info, fixed = TRUE)
+          ver_info[ver_info_start + 1] <-
+            gsub('\\.xx', paste0('\\.', ver_num), ver_info[ver_info_start + 1])
+          ver_info[ver_info_start + 1] <-
+            gsub('\\.yy', paste0('\\.', fix_ver_num), ver_info[ver_info_start+1])
+          writeLines(ver_info, "SS_versioninfo_330safe.tpl")
+          #opt file         
+          ver_info <- readLines("SS_versioninfo_330opt.tpl")
+          ver_info_start <- grep('Create string with version info', ver_info, fixed = TRUE)
+          ver_info[ver_info_start + 1] <-
+            gsub('\\.xx', paste0('\\.', ver_num), ver_info[ver_info_start + 1])
+          ver_info[ver_info_start + 1] <-
+            gsub('\\.yy', paste0('\\.', fix_ver_num), ver_info[ver_info_start+1])
+          writeLines(ver_info, "SS_versioninfo_330opt.tpl")
+        shell: Rscript {0}
           
       - name: Build stock synthesis
         run: |
@@ -32,10 +131,12 @@ jobs:
           shasum -a 256 SS330/ss
           shasum -a 256 SS330/ss_opt
 
-      - name: Delete unneeded files
+      - name: Delete unneeded files and change exe names
         run: |
           cd SS330
           rm *.obj *.htp *.cpp ss_opt.tpl
+          mv ss ss_osx
+          mv ss_opt ss_opt_osx
           
       - name: Archive the binaries
         if: success()

--- a/.github/workflows/build-win-basic.yml
+++ b/.github/workflows/build-win-basic.yml
@@ -2,7 +2,7 @@
 name: build-win-basic
 
 # Controls when the action will run. 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -22,7 +22,102 @@ jobs:
           Invoke-WebRequest -Uri https://github.com/admb-project/admb/releases/download/admb-12.3/admb-12.3-windows.zip -OutFile "D:\a\stock-synthesis\stock-synthesis\admb-12.3.zip"
           Expand-Archive -LiteralPath "D:\a\stock-synthesis\stock-synthesis\admb-12.3.zip" -DestinationPath "D:\a\stock-synthesis\stock-synthesis\"
           echo "D:\a\stock-synthesis\stock-synthesis\admb-12.3\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+            
+      - name: Set up R
+        uses: r-lib/actions/setup-r@master
+        with:
+          r-version: 'release'
+      
+      - name: Fetch tags
+        run: |
+          git fetch --tags
+          git fetch --prune --unshallow || true
           
+      - name: Get the last tag
+        id: get-latest-tag
+        run: |
+          git tag
+          $latest_tag = (git describe --abbrev=0 --tags)
+          $latest_tag_commit = ( git rev-list -n 1 $latest_tag)
+          $latest_commit = (git rev-list HEAD -n 1)
+          echo "::set-output name=tag::${latest_tag}"
+          echo "::set-output name=tag_commit::${latest_tag_commit}"
+          echo "::set-output name=commit::${latest_commit}"
+
+       # uses: actions-ecosystem/action-get-latest-tag@v1 # for linux
+       
+        
+      - name: pull the last tag value to use in the Rscript
+        id: get-version
+        run: |
+          Out-File -InputObject ${{ steps.get-latest-tag.outputs.tag }} -FilePath .github/last_tag.txt
+          Out-File -InputObject ${{ steps.get-latest-tag.outputs.tag_commit }} -FilePath .github/last_tag_commit.txt
+          Out-File -InputObject ${{ steps.get-latest-tag.outputs.commit}} -FilePath .github/last_commit.txt
+
+      - name: Edit the version info for safe version using R code
+        run: |
+          # Get the version
+          # get the last tag from the repository
+          tag_label <- readLines(".github/last_tag.txt")
+          # get commits from from the repository
+          tag_commit <- readLines(".github/last_tag_commit.txt")
+          last_commit <- readLines(".github/last_commit.txt")
+          message("The tag_label is ", tag_label)
+          if (substr(tag_label, start = 1, stop = 6) == "v3.30.") {
+            ver_num_full <- strsplit(tag_label, split = "v3.30", fixed = TRUE)[[1]][2]
+            ver_num <- strsplit(ver_num_full, split = ".", fixed = TRUE)[[1]][2]
+            if(length(grep("-", ver_num)) > 0) {
+              ver_num <- strsplit(ver_num, split = "-", fixed = TRUE)[[1]][1]
+            }
+          } else {
+            ver_num <- "unknown"
+          }
+          message("tag commit: ", tag_commit)
+          message("last  commit: ", last_commit)
+          if(tag_commit == last_commit) {
+            # figure out the version using the tag
+            if(ver_num == "unknown") {
+            fix_ver_num <- "unknown"
+            } else {
+              ver_num_full_split <- strsplit(ver_num_full, split = ".", fixed = TRUE)[[1]]
+              if(length(ver_num_full_split) == 3) {
+                fix_ver_num <- ver_num_full_split[3]
+              } else if(length(ver_num_full_split) == 2) {
+                if(length(grep("-", ver_num_full_split, fixed = TRUE)) > 0) {
+                  fix_ver_num <- strsplit(ver_num_full_split[2], split = "-", fixed = TRUE)[[1]][2]
+                  fix_ver_num <- paste0("00-", fix_ver_num)
+                } else {
+                  fix_ver_num <- "00"
+                }
+              } else {
+                fix_ver_num <- "unknown"
+              }
+            }
+          } else {
+           fix_ver_num <- "beta: not an official version of SS"
+          }
+          message("The minor version label is ", ver_num)
+          message("The patch version label is ", fix_ver_num)
+          
+          # add version numbers to files
+          # safe file
+          ver_info <- readLines("SS_versioninfo_330safe.tpl")
+          ver_info_start <- grep('Create string with version info', ver_info, fixed = TRUE)
+          ver_info[ver_info_start + 1] <-
+            gsub('\\.xx', paste0('\\.', ver_num), ver_info[ver_info_start + 1])
+          ver_info[ver_info_start + 1] <-
+            gsub('\\.yy', paste0('\\.', fix_ver_num), ver_info[ver_info_start+1])
+          writeLines(ver_info, "SS_versioninfo_330safe.tpl")
+          #opt file         
+          ver_info <- readLines("SS_versioninfo_330opt.tpl")
+          ver_info_start <- grep('Create string with version info', ver_info, fixed = TRUE)
+          ver_info[ver_info_start + 1] <-
+            gsub('\\.xx', paste0('\\.', ver_num), ver_info[ver_info_start + 1])
+          ver_info[ver_info_start + 1] <-
+            gsub('\\.yy', paste0('\\.', fix_ver_num), ver_info[ver_info_start+1])
+          writeLines(ver_info, "SS_versioninfo_330opt.tpl")
+        shell: Rscript {0}
+      
       - name: Build stock synthesis
         run: |
           cd Compile
@@ -31,7 +126,8 @@ jobs:
       - name: Move exes to a new folder
         run: |
           mkdir exes
-          mv Compile/ss.exe exes/
+          mv Compile/ss.exe Compile/ss_win.exe
+          mv Compile/ss_win.exe exes/
 
       - name: Archive windows exes
         if: success()

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -32,6 +32,101 @@ jobs:
           Expand-Archive -LiteralPath "D:\a\stock-synthesis\stock-synthesis\admb-12.3.zip" -DestinationPath "D:\a\stock-synthesis\stock-synthesis\"
           echo "D:\a\stock-synthesis\stock-synthesis\admb-12.3\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           
+          
+      - name: Set up R
+        uses: r-lib/actions/setup-r@master
+        with:
+          r-version: 'release'
+      
+      - name: Fetch tags
+        run: |
+          git fetch --tags
+          git fetch --prune --unshallow || true
+          
+      - name: Get the last tag
+        id: get-latest-tag
+        run: |
+          git tag
+          $latest_tag = (git describe --abbrev=0 --tags)
+          $latest_tag_commit = ( git rev-list -n 1 $latest_tag)
+          $latest_commit = (git rev-list HEAD -n 1)
+          echo "::set-output name=tag::${latest_tag}"
+          echo "::set-output name=tag_commit::${latest_tag_commit}"
+          echo "::set-output name=commit::${latest_commit}"
+
+       # uses: actions-ecosystem/action-get-latest-tag@v1 # for linux
+       
+      - name: pull the last tag value to use in the Rscript
+        id: get-version
+        run: |
+          Out-File -InputObject ${{ steps.get-latest-tag.outputs.tag }} -FilePath .github/last_tag.txt
+          Out-File -InputObject ${{ steps.get-latest-tag.outputs.tag_commit }} -FilePath .github/last_tag_commit.txt
+          Out-File -InputObject ${{ steps.get-latest-tag.outputs.commit}} -FilePath .github/last_commit.txt
+
+      - name: Edit the version info for safe version using R code
+        run: |
+          # Get the version
+          # get the last tag from the repository
+          tag_label <- readLines(".github/last_tag.txt")
+          # get commits from from the repository
+          tag_commit <- readLines(".github/last_tag_commit.txt")
+          last_commit <- readLines(".github/last_commit.txt")
+          message("The tag_label is ", tag_label)
+          if (substr(tag_label, start = 1, stop = 6) == "v3.30.") {
+            ver_num_full <- strsplit(tag_label, split = "v3.30", fixed = TRUE)[[1]][2]
+            ver_num <- strsplit(ver_num_full, split = ".", fixed = TRUE)[[1]][2]
+            if(length(grep("-", ver_num)) > 0) {
+              ver_num <- strsplit(ver_num, split = "-", fixed = TRUE)[[1]][1]
+            }
+          } else {
+            ver_num <- "unknown"
+          }
+          message("tag commit: ", tag_commit)
+          message("last  commit: ", last_commit)
+          if(tag_commit == last_commit) {
+            # figure out the version using the tag
+            if(ver_num == "unknown") {
+            fix_ver_num <- "unknown"
+            } else {
+              ver_num_full_split <- strsplit(ver_num_full, split = ".", fixed = TRUE)[[1]]
+              if(length(ver_num_full_split) == 3) {
+                fix_ver_num <- ver_num_full_split[3]
+              } else if(length(ver_num_full_split) == 2) {
+                if(length(grep("-", ver_num_full_split, fixed = TRUE)) > 0) {
+                  fix_ver_num <- strsplit(ver_num_full_split[2], split = "-", fixed = TRUE)[[1]][2]
+                  fix_ver_num <- paste0("00-", fix_ver_num)
+                } else {
+                  fix_ver_num <- "00"
+                }
+              } else {
+                fix_ver_num <- "unknown"
+              }
+            }
+          } else {
+           fix_ver_num <- "beta: not an official version of SS"
+          }
+          message("The minor version label is ", ver_num)
+          message("The patch version label is ", fix_ver_num)
+          
+          # add version numbers to files
+          # safe file
+          ver_info <- readLines("SS_versioninfo_330safe.tpl")
+          ver_info_start <- grep('Create string with version info', ver_info, fixed = TRUE)
+          ver_info[ver_info_start + 1] <-
+            gsub('\\.xx', paste0('\\.', ver_num), ver_info[ver_info_start + 1])
+          ver_info[ver_info_start + 1] <-
+            gsub('\\.yy', paste0('\\.', fix_ver_num), ver_info[ver_info_start+1])
+          writeLines(ver_info, "SS_versioninfo_330safe.tpl")
+          #opt file         
+          ver_info <- readLines("SS_versioninfo_330opt.tpl")
+          ver_info_start <- grep('Create string with version info', ver_info, fixed = TRUE)
+          ver_info[ver_info_start + 1] <-
+            gsub('\\.xx', paste0('\\.', ver_num), ver_info[ver_info_start + 1])
+          ver_info[ver_info_start + 1] <-
+            gsub('\\.yy', paste0('\\.', fix_ver_num), ver_info[ver_info_start+1])
+          writeLines(ver_info, "SS_versioninfo_330opt.tpl")
+        shell: Rscript {0}
+        
       - name: Build stock synthesis
         run: |
           cd Compile
@@ -43,7 +138,9 @@ jobs:
           mkdir exes
           mv Compile/ss.exe exes/
           mv Compile/ss_opt.exe exes/
-
+          mv exes/ss.exe exes/ss_win.exe
+          mv exes/ss_opt.exe exes/ss_opt_win.exe
+  
       - name: Archive windows exes
         if: success()
         uses: actions/upload-artifact@main

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ ss_opt.tpl
 ss_trans.tpl
 ~$*.*
 Compile/ss.log
+.Rproj.user
+*.Rproj
+.Rhistory

--- a/SS_versioninfo_330opt.tpl
+++ b/SS_versioninfo_330opt.tpl
@@ -5,7 +5,7 @@ DATA_SECTION
 !!//  SS_Label_Section_1.0 #DATA_SECTION
 
 !!//  SS_Label_Info_1.1.1  #Create string with version info
-!!version_info+="#V3.30.18.Beta;_fast(opt);_compile_date:_";
+!!version_info+="#V3.30.xx.yy;_fast(opt);_compile_date:_";
 !!version_info+=__DATE__;
 !!version_info+=";_Stock_Synthesis_by_Richard_Methot_(NOAA)_using_ADMB_12.3";
 !!version_info2+="#_Stock_Synthesis_(SS)_is_a_work_of_the_U.S._Government_and_is_not_subject_to_copyright_protection_in_the_United_States.";

--- a/SS_versioninfo_330safe.tpl
+++ b/SS_versioninfo_330safe.tpl
@@ -5,7 +5,7 @@ DATA_SECTION
 !!//  SS_Label_Section_1.0 #DATA_SECTION
 
 !!//  SS_Label_Info_1.1.1  #Create string with version info
-!!version_info+="#V3.30.18.Beta;_safe;_compile_date:_";
+!!version_info+="#V3.30.xx.yy;_safe;_compile_date:_";
 !!version_info+=__DATE__;
 !!version_info+=";_Stock_Synthesis_by_Richard_Methot_(NOAA)_using_ADMB_12.3";
 !!version_info2+="#_Stock_Synthesis_(SS)_is_a_work_of_the_U.S._Government_and_is_not_subject_to_copyright_protection_in_the_United_States.";


### PR DESCRIPTION
This PR addresses #202. Now, version info is automatically added based on tags. If a tag with the same commit has been added and has the right format (v3.30.xx.yy, v3.30.xx, or v3.30.xx-prerel), the version as in the tag will be added to the SS version info file before compilation. Otherwise, the last xx version will be used, with .yy = .beta (e.g., a commit after v3.30.17 but before v.3.30.18 and that isn't tagged would be labeled v.3.30.xx.beta).

Note this change does not affect the date of compilation, which will be the true date of compilation due to the use of __DATE__ in the version info.