### PR TITLE
build: add tests for r4ss ss_plots fxn, testing mcmc

### DIFF
--- a/.github/workflows/call-run-ss3-mcmc.yml
+++ b/.github/workflows/call-run-ss3-mcmc.yml
@@ -1,0 +1,10 @@
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+name: call-build-ss3
+jobs:
+  call-workflow:
+    uses: nmfs-stock-synthesis/workflows/.github/workflows/run-ss3-mcmc.yml@main

--- a/.github/workflows/call-test-r4ss-with-ss3.yml
+++ b/.github/workflows/call-test-r4ss-with-ss3.yml
@@ -1,0 +1,10 @@
+on: 
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+name: call-test-r4ss-with-ss3
+jobs:
+  call-workflow:
+    uses: nmfs-stock-synthesis/workflows/.github/workflows/test-r4ss-with-ss3.yml@main


### PR DESCRIPTION
Adds files to test r4ss with the main branch of ss and for testing that mcmc sampling was working.

These were available on Jenkins, but I am planning on deprecating Jenkins in the not so distant future since we don't run it as often.