### PR TITLE
one line fix for issue #205

### DIFF
--- a/SS_benchfore.tpl
+++ b/SS_benchfore.tpl
@@ -2429,7 +2429,6 @@ FUNCTION void Get_Forecast()
 
             if((Fcast_Loop1==2 || Fcast_Loop_Control(1)==1) && ABC_Loop==1)  // get variance in OFL
             {
-              Mgmt_quant(Fcast_catch_start+N_Fcast_Yrs+y-endyr)=0.;
               for(int ff=1;ff<=N_catchfleets(0);ff++)
               {f=fish_fleet_area(0,ff);
                 if(fleet_type(f)==1)


### PR DESCRIPTION
This problem affected forecast of OFL catch in a model with seasons
OFL catch contained only catch from Nseas
Fix involved deleting one line that was re-initializing that quantity