### PR TITLE
Github actions: only build tests on changes to tpl files

### DIFF
--- a/.github/workflows/call-build-ss3-centos.yml
+++ b/.github/workflows/call-build-ss3-centos.yml
@@ -1,9 +1,13 @@
 on: 
   workflow_dispatch:
   push:
+    paths:
+      - '**.tpl'
     branches:
       - main
   pull_request:
+    paths:
+      - '**.tpl'
     branches:
       - main
 name: call-build-ss3-centos

--- a/.github/workflows/call-build-ss3-warnings.yml
+++ b/.github/workflows/call-build-ss3-warnings.yml
@@ -2,9 +2,13 @@ name:  call-build-ss3-warnings
 on:
   workflow_dispatch:
   push:
+    paths:
+      - '**.tpl'
     branches:
       - main
   pull_request:
+    paths:
+      - '**.tpl'
     branches:
       - main
 jobs:

--- a/.github/workflows/call-build-ss3.yml
+++ b/.github/workflows/call-build-ss3.yml
@@ -1,5 +1,12 @@
-on: [push, pull_request, workflow_dispatch]
 name: call-build-ss3
+on: 
+  push:
+    paths:
+    - '**.tpl'
+  pull_request:
+    paths:
+      - '**.tpl'
+  workflow_dispatch:
 jobs:
   call-workflow:
     uses: nmfs-stock-synthesis/workflows/.github/workflows/build-ss3.yml@main

--- a/.github/workflows/call-run-ss3-mcmc.yml
+++ b/.github/workflows/call-run-ss3-mcmc.yml
@@ -1,8 +1,12 @@
 on:
   workflow_dispatch:
   push:
+    paths:
+      - '**.tpl'
     branches: [main]
   pull_request:
+    paths:
+      - '**.tpl'
     branches: [main]
 name: call-build-ss3
 jobs:

--- a/.github/workflows/call-run-ss3-no-est.yml
+++ b/.github/workflows/call-run-ss3-no-est.yml
@@ -1,6 +1,13 @@
 # run models without estimation
 name: run-no-est
-on: [push, pull_request, workflow_dispatch]
+on: 
+  push:
+    paths:
+    - '**.tpl'
+  pull_request:
+    paths:
+      - '**.tpl'
+  workflow_dispatch:
 
 jobs:
   call-workflow:

--- a/.github/workflows/call-run-ss3-with-est.yml
+++ b/.github/workflows/call-run-ss3-with-est.yml
@@ -1,7 +1,13 @@
 # run models without estimation
 name: call-run-ss3-with-est
-on: [push, pull_request, workflow_dispatch]
-
+on: 
+  push:
+    paths:
+    - '**.tpl'
+  pull_request:
+    paths:
+      - '**.tpl'
+  workflow_dispatch:
 jobs:
   call-workflow:
     uses: nmfs-stock-synthesis/workflows/.github/workflows/run-ss3-with-est.yml@main

--- a/.github/workflows/call-test-r4ss-with-ss3.yml
+++ b/.github/workflows/call-test-r4ss-with-ss3.yml
@@ -1,5 +1,4 @@
 on: 
-on: 
   push:
     branches:
       - main

--- a/.github/workflows/call-test-r4ss-with-ss3.yml
+++ b/.github/workflows/call-test-r4ss-with-ss3.yml
@@ -1,9 +1,16 @@
 on: 
-  workflow_dispatch:
+on: 
   push:
-    branches: [main]
+    branches:
+      - main
+    paths:
+      - '**.tpl'
   pull_request:
-    branches: [main]
+    branches: 
+      - main
+    paths:
+      - '**.tpl'
+  workflow_dispatch:
 name: call-test-r4ss-with-ss3
 jobs:
   call-workflow:


### PR DESCRIPTION
Following https://github.com/nmfs-stock-synthesis/workflows/issues/15 , only build the stock synthesis on changes to the .tpl files. However, the option of manually triggering jobs remains, in case situations come up where builds are desired due to changes in other files.