### PR TITLE
Wip herma

### DIFF
--- a/SS_popdyn.tpl
+++ b/SS_popdyn.tpl
@@ -1336,6 +1336,7 @@ FUNCTION void get_time_series()
   //  SS_Label_Info_24.8  #hermaphroditism
       if(Hermaphro_Option!=0)
       {
+              warning<<y<<" "<<s<<" do herm;"<<endl;
         if(Hermaphro_seas==-1 || Hermaphro_seas==s)
         {
           k=gmorph/2;  //  because first half of the "g" are females
@@ -1353,11 +1354,13 @@ FUNCTION void get_time_series()
             } else
             if(Hermaphro_Option==-1)
             {
+          warning<<"changer: "<<Hermaphro_val(GP4(g+k))<<endl<<natage(t+1,p,g)<<endl<<natage(t+1,p,g+k)<<endl;
               for (a=1;a<nages;a++)
               {
                 natage(t+1,p,g,a) += natage(t+1,p,g+k,a)*Hermaphro_val(GP4(g+k),a-1); // increment females with males
                 natage(t+1,p,g+k,a) *= (1.-Hermaphro_val(GP4(g+k),a-1)); // decrement males
               }
+          warning<<"after: "<<endl<<natage(t+1,p,g)<<endl<<natage(t+1,p,g+k)<<endl<<endl;
             }
           }
         }

--- a/SS_readdata_330.tpl
+++ b/SS_readdata_330.tpl
@@ -1704,6 +1704,8 @@
   Nobs_a.initialize();
   Nobs_a_use.initialize();
   N_suprper_a.initialize();
+  Comp_Err_A.initialize();
+  Comp_Err_A2.initialize();
   echoinput<<"Enter the number of agebins, or 0 if no age data"<<endl;
   *(ad_comm::global_datafile) >> n_abins;
   echoinput<<n_abins<<" N age bins "<<endl;
@@ -1760,8 +1762,6 @@
         }
       }
 
-      Comp_Err_A.initialize();
-      Comp_Err_A2.initialize();
       echoinput<<"#_now read for each fleet info for processing the age comps:"<<endl;
       echoinput<<"#_mintailcomp: upper and lower distribution for females and males separately are accumulated until exceeding this level."<<endl;
       echoinput<<"#_addtocomp:  after accumulation of tails; this value added to all bins"<<endl;

--- a/SS_write_report.tpl
+++ b/SS_write_report.tpl
@@ -2554,7 +2554,37 @@ FUNCTION void write_bigoutput()
 
    SS2out<<endl;
    SS2out<<"Seas Morph Bio_Pattern Sex Settlement Platoon int_Age Real_Age Age_Beg Age_Mid M Len_Beg Len_Mid SD_Beg SD_Mid Wt_Beg Wt_Mid Len_Mat Age_Mat Mat*Fecund Mat_F_wtatage Mat_F_Natage";
-   if(Hermaphro_Option!=0) SS2out<<" Herma_Trans Herma_Cum ";
+   if(Hermaphro_Option!=0) 
+   {
+     SS2out<<" Herma_Trans Herma_Cum ";
+      {if(sx(g)==1) {Herma_Cum=femfrac(GP(g));} else {Herma_Cum=1.0-femfrac(GP(g));}}
+
+        {
+          k=gmorph/2;  //  because first half of the "g" are females
+          for (g=1;g<=k;g++)  //  loop
+          if(Hermaphro_seas==-1 || Hermaphro_seas==s)
+          if(use_morph(g)>0)
+          {
+            if(Hermaphro_Option==1)
+            {
+              for (a=1;a<nages;a++)
+              {
+                natage(t+1,p,g+k,a) += natage(t+1,p,g,a)*Hermaphro_val(GP4(g),a-1); // increment males with females
+                natage(t+1,p,g,a) *= (1.-Hermaphro_val(GP4(g),a-1)); // decrement females
+              }
+            } else
+            if(Hermaphro_Option==-1)
+            {
+              for (a=1;a<nages;a++)
+              {
+                natage(t+1,p,g,a) += natage(t+1,p,g+k,a)*Hermaphro_val(GP4(g+k),a-1); // increment females with males
+                natage(t+1,p,g+k,a) *= (1.-Hermaphro_val(GP4(g+k),a-1)); // decrement males
+              }
+            }
+          }
+        }
+   }
+
    for (f=1;f<=Nfleet;f++) SS2out<<" Len:_"<<f<<" SelWt:_"<<f<<" RetWt:_"<<f;
    SS2out<<endl;
    for (s=1;s<=nseas;s++)
@@ -2565,10 +2595,8 @@ FUNCTION void write_bigoutput()
      for (g=1;g<=gmorph;g++)
      if(use_morph(g)>0)
      {
-     Herma_Cum=femfrac(GP(g));
      for (a=0;a<=nages;a++)
      {
-
       SS2out<<s<<" "<<g<<" "<<GP4(g)<<" "<<sx(g)<<" "<<settle_g(g)<<" "<<GP2(g)<<" "<<a<<" "<<real_age(g,ALK_idx,a)<<" "<<calen_age(g,ALK_idx,a)<<" "<<calen_age(g,ALK_idx_mid,a);
       SS2out<<" "<<natM(s,GP3(g),a)<<" "<<Ave_Size(t,1,g,a)<<" "<<Ave_Size(t,mid_subseas,g,a)<<" "
         <<Sd_Size_within(ALK_idx,g,a)<<" "<<Sd_Size_within(ALK_idx_mid,g,a)<<" "
@@ -2580,10 +2608,25 @@ FUNCTION void write_bigoutput()
       else
         {SS2out<<-1.;}
       SS2out<<" "<<fec(g,a)<<" "<<make_mature_bio(g,a)<<" "<<make_mature_numbers(g,a);
-      if(Hermaphro_Option!=0)
+      if(Hermaphro_Option==1)
       {
-        if(a>1) Herma_Cum*=(1.0-Hermaphro_val(GP4(g),a-1));
-        SS2out<<" "<<Hermaphro_val(GP4(g),a)<<" "<<Herma_Cum;
+        if(sx(g)==1) 
+        {
+          if((Hermaphro_seas==-1 || Hermaphro_seas==s) && (a>0)) Herma_Cum*=(1.0-Hermaphro_val(GP4(g),a-1));
+          SS2out<<" "<<Hermaphro_val(GP4(g),a)<<" "<<Herma_Cum;
+        } 
+        else 
+        {SS2out<<" NA "<<1.0-Herma_Cum;}
+      }
+      else if(Hermaphro_Option==-1)
+      {
+        if(sx(g)==2) 
+        {
+          if((Hermaphro_seas==-1 || Hermaphro_seas==s) && (a>0)) Herma_Cum*=(1.0-Hermaphro_val(GP4(g),a-1));
+          SS2out<<" "<<Hermaphro_val(GP4(g),a)<<" "<<1.0-Herma_Cum;
+        } 
+        else 
+        {SS2out<<" NA "<<Herma_Cum;}
       }
       if(WTage_rd==0)
       {

--- a/SS_write_report.tpl
+++ b/SS_write_report.tpl
@@ -2554,37 +2554,8 @@ FUNCTION void write_bigoutput()
 
    SS2out<<endl;
    SS2out<<"Seas Morph Bio_Pattern Sex Settlement Platoon int_Age Real_Age Age_Beg Age_Mid M Len_Beg Len_Mid SD_Beg SD_Mid Wt_Beg Wt_Mid Len_Mat Age_Mat Mat*Fecund Mat_F_wtatage Mat_F_Natage";
-   if(Hermaphro_Option!=0) 
-   {
-     SS2out<<" Herma_Trans Herma_Cum ";
-      {if(sx(g)==1) {Herma_Cum=femfrac(GP(g));} else {Herma_Cum=1.0-femfrac(GP(g));}}
-
-        {
-          k=gmorph/2;  //  because first half of the "g" are females
-          for (g=1;g<=k;g++)  //  loop
-          if(Hermaphro_seas==-1 || Hermaphro_seas==s)
-          if(use_morph(g)>0)
-          {
-            if(Hermaphro_Option==1)
-            {
-              for (a=1;a<nages;a++)
-              {
-                natage(t+1,p,g+k,a) += natage(t+1,p,g,a)*Hermaphro_val(GP4(g),a-1); // increment males with females
-                natage(t+1,p,g,a) *= (1.-Hermaphro_val(GP4(g),a-1)); // decrement females
-              }
-            } else
-            if(Hermaphro_Option==-1)
-            {
-              for (a=1;a<nages;a++)
-              {
-                natage(t+1,p,g,a) += natage(t+1,p,g+k,a)*Hermaphro_val(GP4(g+k),a-1); // increment females with males
-                natage(t+1,p,g+k,a) *= (1.-Hermaphro_val(GP4(g+k),a-1)); // decrement males
-              }
-            }
-          }
-        }
-   }
-
+   if(Hermaphro_Option!=0) {SS2out<<" Herma_Trans ";}
+   if(gender==2) SS2out<<" sex_ratio ";
    for (f=1;f<=Nfleet;f++) SS2out<<" Len:_"<<f<<" SelWt:_"<<f<<" RetWt:_"<<f;
    SS2out<<endl;
    for (s=1;s<=nseas;s++)
@@ -2612,21 +2583,27 @@ FUNCTION void write_bigoutput()
       {
         if(sx(g)==1) 
         {
-          if((Hermaphro_seas==-1 || Hermaphro_seas==s) && (a>0)) Herma_Cum*=(1.0-Hermaphro_val(GP4(g),a-1));
-          SS2out<<" "<<Hermaphro_val(GP4(g),a)<<" "<<Herma_Cum;
+          SS2out<<" "<<Hermaphro_val(GP4(g),a)<<" ";
         } 
         else 
-        {SS2out<<" NA "<<1.0-Herma_Cum;}
+        {SS2out<<" NA ";}
       }
       else if(Hermaphro_Option==-1)
       {
         if(sx(g)==2) 
         {
-          if((Hermaphro_seas==-1 || Hermaphro_seas==s) && (a>0)) Herma_Cum*=(1.0-Hermaphro_val(GP4(g),a-1));
-          SS2out<<" "<<Hermaphro_val(GP4(g),a)<<" "<<1.0-Herma_Cum;
+          SS2out<<" "<<Hermaphro_val(GP4(g),a)<<" ";
         } 
         else 
-        {SS2out<<" NA "<<Herma_Cum;}
+        {SS2out<<" NA ";}
+      }
+//  write sex ratio in endyr using natage in area 1
+      if(gender==2)
+      {
+        if(sx(g)==1)
+          {SS2out<<natage(t,1,g,a)/(natage(t,1,g,a)+natage(t,1,g+gmorph/2,a))<<" ";}
+          else
+          {SS2out<<natage(t,1,g,a)/(natage(t,1,g,a)+natage(t,1,g-gmorph/2,a))<<" ";}
       }
       if(WTage_rd==0)
       {


### PR DESCRIPTION
@k-doering-NOAA 
@chantelwetzel-noaa 
@iantaylor-NOAA 
This corrects the biology_at_age_in_endyr output for hermaphroditism
herm_trans column is removed
replaced with sex_ratio calculated from numbers-at-age in endyr
ALSO!  the sex_ratio column will now appear in all 2 sex configurations, so will be new for r4ss
it is omitted in 1 sex models