### PR TITLE
Issue 228 - remove and warn unused selex patterns

### DIFF
--- a/SS_selex.tpl
+++ b/SS_selex.tpl
@@ -113,7 +113,7 @@ FUNCTION void get_selectivity()
           {
 			N_warn++;
 			cout << "EXIT - see warning" << endl;
-			warning << N_warn << " " << "Selectivity pattern 4 discontinued; use pattern 0 and special survey pattern 30 in data file instead."<<endl; 
+			warning << N_warn << " " << "Selectivity pattern 4 discontinued; use pattern 0 and special survey units 30 in data file instead."<<endl; 
 			exit(1); 
 			break;
 		  }

--- a/SS_selex.tpl
+++ b/SS_selex.tpl
@@ -70,8 +70,10 @@ FUNCTION void get_selectivity()
           {
   //  SS_Label_Info_22.3.0 #case 0 constant size selectivity
             case 0:   // ***********   constant
-             {sel = 1.;break;}
-
+             {
+			   sel = 1.;
+			   break;
+			 }
   //  SS_Label_Info_22.3.1 #case 1 logistic size selectivity
             case 1:
               {
@@ -87,85 +89,34 @@ FUNCTION void get_selectivity()
               }
 
   //  SS_Label_Info_22.3.2 #case 2 discontinued; use pattern 8 for double logistic
-  //  SS_Label_Info_22.3.24 #case 24 size selectivity using double_normal_plateau and lots of bells and whistles
-            case 2:
-              {
-          if(seltype(f,3)<3 || (gg==1 && seltype(f,3)==3) || (gg==2 && seltype(f,3)==4))
-            {peak=sp(1); upselex=mfexp(sp(3)); downselex=mfexp(sp(4)); final=sp(6); Apical_Selex=1.;}
-            else
-            {   // offset male parameters if seltype(f,3)==3, female parameters if seltype(f,3)==4
-              peak=sp(1)+sp(Maleselparm(f));
-              upselex=mfexp(sp(3)+sp(Maleselparm(f)+1));
-              downselex=mfexp(sp(4)+sp(Maleselparm(f)+2));
-              if(sp(6)>-999.) final=sp(6)+sp(Maleselparm(f)+3);
-              Apical_Selex=sp(Maleselparm(f)+4);
-            }
-
-            if(sp(5)<-1000.)
-            {
-              j1=-1001-int(value(sp(5)));      // selex is nil thru bin j1, so set sp(5) equal to first bin with selex (e.g. -1002 to start selex at bin 2)
-              sel(1,j1)=1.0e-06;
-            }
-            else
-            {
-              j1=startbin-1;                // start selex at bin equal to min sizecomp databin  (=j1+1)
-              if(sp(5)>-999)
-              {
-                point1=1.0/(1.0+mfexp(-sp(5)));
-              t1min=mfexp(-(square(len_bins_m(startbin)-peak)/upselex));  // fxn at first bin
-              }
-            }
-            if(sp(6)<-1000.)
-            {
-              j2=-1000-int(value(sp(6))); // selex is constant beyond this sizebin, so set sp(6) equal to last bin with estimated selex
-            }
-            else
-            {j2=nlength;}
-            peak2=peak+binwidth2+ (0.99*len_bins_m(j2)-peak-binwidth2)/(1.+mfexp(-sp(2)));
-            if(sp(6)>-999)
-            {
-//              point2=1.0/(1.0+mfexp(-final));
-              point2=Apical_Selex/(1.0+mfexp(-final));
-              t2min=mfexp(-(square(len_bins_m(j2)-peak2)/downselex));  // fxn at last bin
-            }
-            for (j=j1+1;j<=j2;j++)
-            {
-              t1=len_bins_m(j)-peak;  t2=len_bins_m(j)-peak2;
-              join1=1.0/(1.0+mfexp(-(20.*t1/(1.0+fabs(t1)))));  //  note the logit transform on t1 causes range of mfexp to be over -20 to 20
-              join2=1.0/(1.0+mfexp(-(20.*t2/(1.0+fabs(t2)))));
-              if(sp(5)>-999)
-                {asc=point1+(Apical_Selex-point1)*(mfexp(-square(t1)/upselex)-t1min)/(1.0-t1min);}
-              else
-                {asc=Apical_Selex*mfexp(-square(t1)/upselex);}
-              if(sp(6)>-999)
-                {dsc=Apical_Selex+(point2-Apical_Selex)*(mfexp(-square(t2)/downselex)-1.0    )/(t2min-1.0);}
-              else
-                {dsc=Apical_Selex*mfexp(-square(t2)/downselex);}
-              sel(j)=asc*(1.0-join1)+join1*(Apical_Selex*(1.0-join2)+dsc*join2);
-            }
-            if(startbin>1 && sp(5)>=-1000.)
-            {
-              for (j=1;j<=startbin-1;j++)
-              {
-                sel(j)=square(len_bins_m(j)/len_bins_m(startbin))*sel(startbin);
-              }
-            }
-
-            if(j2<nlength) {sel(j2+1,nlength)=sel(j2);}
-            break;
-          }
-
+           case 2:
+		   {
+             N_warn++; 
+			 cout<<" EXIT - see warning"<<endl; 
+			 warning<<N_warn<<" "<<"Selectivity pattern 2 discontinued; use pattern 8 instead."<<endl; 
+			 exit(1);
+             break;
+           }
 
   //  SS_Label_Info_22.3.3 #case 3 discontinued
           case 3:
           {
-            N_warn++; cout<<" EXIT - see warning "<<endl;  warning<<N_warn<<" "<<" selex pattern 3 discontinued "<<endl; exit(1);
-           break;
-          }  // end seltype=3
+            N_warn++;
+			cout << "EXIT - see warning" << endl;
+			warning << N_warn << " " << "Selectivity pattern 3 discontinued. Use a different pattern." << endl;
+			exit(1);
+            break;
+          }
 
   //  SS_Label_Info_22.3.4 #case 4 discontinued; use pattern 30 to get spawning biomass
           case 4:
-            {N_warn++; cout<<" EXIT - see warning "<<endl;  warning<<N_warn<<" "<<" selex pattern 4 discontinued; use pattern 30 to get spawning biomass "<<endl; exit(1); break;}                   // do this as a numbers survey because wt is included here
+          {
+			N_warn++;
+			cout << "EXIT - see warning" << endl;
+			warning << N_warn << " " << "Selectivity pattern 4 discontinued; use pattern 0 and special survey pattern 30 in data file instead."<<endl; 
+			exit(1); 
+			break;
+		  }
 
   //  SS_Label_Info_22.3.5 #case 5 mirror another fleets size selectivity for specified bin range
   //  use only the specified bin range using mirror_mask created upon read
@@ -260,47 +211,23 @@ FUNCTION void get_selectivity()
           }
 
   //  SS_Label_Info_22.3.7 #case 7 discontinued; use pattern 8 for double logistic
-          case 7:                  // *******New double logistic
-    // 1=peak, 2=init,  3=infl,  4=slope, 5=final, 6=infl2, 7=slope2 8=binwidth;    Mirror=1===const_above_Linf
+          case 7:
           {
-            N_warn++; cout<<" EXIT - see warning "<<endl;  warning<<N_warn<<" "<<" selex pattern 7 discontinued; use pattern 8 for double logistic "<<endl; exit(1);
- /*
-           t1=minL+(1./(1.+mfexp(-sp(3))))*(sp(1)-minL);    // INFL
-           t1min=1./(1.+mfexp(-sp(4)*(minL-t1)))*0.9999;  // asc value at minsize
-           t1max=1./(1.+mfexp(-sp(4)*(sp(1)-t1)))*1.00001;  // asc value at peak
-           t1power=log(0.5)/log((0.5-t1min)/(t1max-t1min));  // so the parameter will actual correspond to 50% point
-
-           if(seltype(f,4)==0) {sel_maxL=maxL;} else {sel_maxL=Ave_Size(styr,3,1,nages);}
-           t2=(sp(1)+sp(8))+(1./(1.+mfexp(-sp(6))))*(sel_maxL-(sp(1)+sp(8)));    // INFL
-           t2min=1./(1.+mfexp(-sp(7)*(sp(1)+sp(8)-t2)))*0.9999;  // asc value at peak+
-           t2max=1./(1.+mfexp(-sp(7)*(sel_maxL-t2)))*1.00001;  // asc value at maxL
-           t2power=log(0.5)/log((0.5-t2min)/(t2max-t2min));
-           final=1./(1.+mfexp(-sp(5)));
-
-           for (j=1; j<=nlength; j++)  //calculate the value over length bins
-           {sel(j) =
-             (
-             (
-             (sp(2) + (1. - sp(2)) * pow((( 1./(1.+mfexp(-sp(4)*(len_bins_m(j)-t1))) -t1min ) / (t1max-t1min) ),t1power))
-              /(1.+mfexp(10.*(len_bins_m(j)-sp(1))))   // scale ascending side
-              +
-              1./(1.+mfexp(-10.*(len_bins_m(j)-sp(1))))   // flattop, with scaling
-              )
-              /(1.+mfexp( 10.*(len_bins_m(j)-(sp(1)+sp(8)))))    // scale combo of ascending and flattop
-              +
-              (1. + (final - 1.) * pow(sqrt(square((( 1./(1.+mfexp(-sp(7)*(len_bins_m(j)-t2))) -t2min ) / (t2max-t2min) ))),t2power))
-              /(1.+mfexp( -10.*(len_bins_m(j)-(sp(1)+sp(8)))))    // scale descending
-              ) / (1.+mfexp(10.*(len_bins_m(j)-sel_maxL)));       // scale combo of ascend, flattop, descending
-             sel(j)+=final/(1.+mfexp(-10.*(len_bins_m(j)-sel_maxL)));  // add scaled portion above Linf
-           }   // end size bin loop
-  */
-           break;
-          }    // end New double logistic
+            N_warn++;
+			cout<<" EXIT - see warning "<<endl;
+			warning<<N_warn<<" "<<"Selectivity pattern 7 discontinued; use pattern 8 instead for double logistic. "<<endl;
+			exit(1);
+            break;
+          }
 
   //  SS_Label_Info_22.3.8 #case 8 double logistic  with eight parameters
-          case 8:                  // *******New double logistic in simpler code
+          case 8:
+
     // 1=peak, 2=init,  3=infl,  4=slope, 5=final, 6=infl2, 7=slope2 8=binwidth;    Mirror=1===const_above_Linf
           {
+		   N_warn++; 
+		   warning << N_warn << " " << "Selectivity pattern 24 is recommended over pattern 8 because it has fewer parameters."<<endl;
+		   
            t1=minL+(1./(1.+mfexp(-sp(3))))*(sp(1)-minL);    // INFL
            t1min=1./(1.+mfexp(-mfexp(sp(4))*(minL-t1)))*0.9999;  // asc value at minsize
            t1max=1./(1.+mfexp(-mfexp(sp(4))*(sp(1)-t1)))*1.0001;  // asc value at peak
@@ -617,11 +544,21 @@ FUNCTION void get_selectivity()
             }
             break;
           } // end cubic spline (type 42 or 27)
-
-          default:
+          case 30:
+		    {
+		      N_warn++; 
+			  cout << " EXIT - see warning "<<endl;  
+			  warning << N_warn << " " << "Selectivity pattern 30 not valid. Please set up in survey units instead and use pattern 0 for selectivity." << endl; 
+			  exit(1);
+		      break;
+		    }
+          default: // Selectivity pattern not found
           	{
-          		sel=1.0;
-          		break;
+          	  N_warn++; 
+			  cout << " EXIT - see warning "<<endl;  
+			  warning << N_warn << " " << "Length Selectivity Pattern " << seltype(f,1) << " not valid." << endl; 
+			  exit(1);
+		      break;
           	}
           } // end select the selectivity pattern
           sel_l(y,f,gg)=sel;    // Store size-selex in year*type array
@@ -1180,9 +1117,11 @@ FUNCTION void get_selectivity()
             }
 
   //  SS_Label_Info_22.7.18 #age selectivity: double logistic with smooth transition
-              case 18:                 // *******double logistic with smooth transition
+              case 18:
                                        // 1=peak, 2=init,  3=infl,  4=slope, 5=final, 6=infl2, 7=slope2
             {
+			 N_warn++; 
+		     warning << N_warn << " " << "Selectivity pattern 20 is recommended over pattern 18 because it has fewer parameters."<<endl;
              sel_a(y,fs,1).initialize();
              t1=0.+(1./(1.+mfexp(-sp(3))))*(sp(1)-0.);    // INFL
              t1min=1./(1.+mfexp(-sp(4)*(0.-t1)))*0.9999;  // asc value at minsize
@@ -1375,7 +1314,9 @@ FUNCTION void get_selectivity()
 
           default:   //  seltype not found.  But really need this check earlier when the N selex parameters are being processed.
           {
-            N_warn++; cout<<"Critical error, see warning"<<endl;  warning<<N_warn<<" "<<"Age_selex option not valid "<<seltype(f,1)<<endl; exit(1);
+            N_warn++; cout<<"EXIT - see warning"<<endl;  
+			warning << N_warn << " " << "Age selectivity option " << seltype(f,1) << " not valid." << endl;
+			exit(1);
             break;
           }
 

--- a/SS_selex.tpl
+++ b/SS_selex.tpl
@@ -215,7 +215,7 @@ FUNCTION void get_selectivity()
           {
             N_warn++;
 			cout<<" EXIT - see warning "<<endl;
-			warning<<N_warn<<" "<<"Selectivity pattern 7 discontinued; use pattern 8 instead for double logistic. "<<endl;
+			warning<<N_warn<<" "<<"Selectivity pattern 7 discontinued; use pattern 8 instead for double logistic, but recommend pattern 24. "<<endl;
 			exit(1);
             break;
           }
@@ -225,9 +225,15 @@ FUNCTION void get_selectivity()
 
     // 1=peak, 2=init,  3=infl,  4=slope, 5=final, 6=infl2, 7=slope2 8=binwidth;    Mirror=1===const_above_Linf
           {
-		   N_warn++; 
-		   warning << N_warn << " " << "Selectivity pattern 24 is recommended over pattern 8 because it has fewer parameters."<<endl;
-		   
+		  
+		 #ifdef DO_ONCE
+			if(do_once==1)
+			{
+			  N_warn++; 
+		      warning << N_warn << " " << "Selectivity pattern 24 is recommended over pattern 8 because it has fewer parameters."<<endl;
+			}
+		 #endif
+
            t1=minL+(1./(1.+mfexp(-sp(3))))*(sp(1)-minL);    // INFL
            t1min=1./(1.+mfexp(-mfexp(sp(4))*(minL-t1)))*0.9999;  // asc value at minsize
            t1max=1./(1.+mfexp(-mfexp(sp(4))*(sp(1)-t1)))*1.0001;  // asc value at peak
@@ -865,7 +871,13 @@ FUNCTION void get_selectivity()
               case 13:
                                        // 1=peak, 2=init,  3=infl,  4=slope, 5=final, 6=infl2, 7=slope2, 8=plateau
               {
-               	sel_a(y,fs,1).initialize();
+			  #ifdef DO_ONCE
+                if(do_once == 1) {
+				  N_warn++;  
+				  warning<<N_warn<<" "<<" Age selectivity pattern 13 used; suggest using pattern 18 instead. "<<endl;
+				}
+              #endif
+             	sel_a(y,fs,1).initialize();
                 t1=0.+(1./(1.+mfexp(-sp(3))))*(sp(1)-0.);    // INFL
                 t1min=1./(1.+mfexp(-sp(4)*(0.-t1)))*0.9999999;  // asc value at minage
                 t1max=1./(1.+mfexp(-sp(4)*(sp(1)-t1)))*1.00001;  // asc value at peak
@@ -1120,8 +1132,15 @@ FUNCTION void get_selectivity()
               case 18:
                                        // 1=peak, 2=init,  3=infl,  4=slope, 5=final, 6=infl2, 7=slope2
             {
-			 N_warn++; 
-		     warning << N_warn << " " << "Selectivity pattern 20 is recommended over pattern 18 because it has fewer parameters."<<endl;
+			
+			#ifdef DO_ONCE
+			  if(do_once==1)
+			  {
+			    N_warn++; 
+		        warning << N_warn << " " << "Selectivity pattern 20 is recommended over pattern 18 because it has fewer parameters."<<endl;
+			  }
+		    #endif
+
              sel_a(y,fs,1).initialize();
              t1=0.+(1./(1.+mfexp(-sp(3))))*(sp(1)-0.);    // INFL
              t1min=1./(1.+mfexp(-sp(4)*(0.-t1)))*0.9999;  // asc value at minsize

--- a/SS_selex.tpl
+++ b/SS_selex.tpl
@@ -137,8 +137,6 @@ FUNCTION void get_selectivity()
 		                  warning << N_warn << " " << "Note: Selectivity 2 is a back-compatible (SS 3.30.18 and earlier) version of selectivity 24. Recommend using 24."<<endl;
 			            }
 		               #endif
-						Nwarn++; 
-						warning << Nwarn << " " << "Note: using selectivity 2" << endl;
 					}
 				  t2min=mfexp(-(square(len_bins_m(j2)-peak2)/downselex));  // fxn at last bin
 				}

--- a/SS_write_ssnew.tpl
+++ b/SS_write_ssnew.tpl
@@ -1917,6 +1917,7 @@ FUNCTION void write_nucontrol()
    report4<<"#Pattern:_22; parm=4; double_normal as in CASAL"<<endl;
    report4<<"#Pattern:_23; parm=6; double_normal where final value is directly equal to sp(6) so can be >1.0"<<endl;
    report4<<"#Pattern:_24; parm=6; double_normal with sel(minL) and sel(maxL), using joiners"<<endl;
+   report4<<"#Pattern:_2;  parm=6; double_normal with sel(minL) and sel(maxL), using joiners, back compatibile version of 24 with 3.30.18 and older"<<endl;
    report4<<"#Pattern:_25; parm=3; exponential-logistic in length"<<endl;
    report4<<"#Pattern:_27; parm=special+3; cubic spline in length; parm1==1 resets knots; parm1==2 resets all "<<endl;
    report4<<"#Pattern:_42; parm=special+3+2; cubic spline; like 27, with 2 additional param for scaling (average over bin range)"<<endl;

--- a/SS_write_ssnew.tpl
+++ b/SS_write_ssnew.tpl
@@ -1906,7 +1906,6 @@ FUNCTION void write_nucontrol()
 
    report4<<"#Pattern:_0;  parm=0; selex=1.0 for all sizes"<<endl;
    report4<<"#Pattern:_1;  parm=2; logistic; with 95% width specification"<<endl;
-   report4<<"#Pattern:_2;  parm=6; modification of pattern 24 with improved sex-specific offset"<<endl;
    report4<<"#Pattern:_5;  parm=2; mirror another size selex; PARMS pick the min-max bin to mirror"<<endl;
    report4<<"#Pattern:_11; parm=2; selex=1.0  for specified min-max population length bin range"<<endl;
    report4<<"#Pattern:_15; parm=0; mirror another age or length selex"<<endl;
@@ -1927,13 +1926,12 @@ FUNCTION void write_nucontrol()
    for (f=1;f<=Nfleet;f++) report4<<seltype_rd(f)<<" # "<<f<<" "<<fleetname(f)<<endl;
    report4<<"#"<<endl;
 
-
    report4<<"#_age_selex_patterns"<<endl;
    report4<<"#Pattern:_0; parm=0; selex=1.0 for ages 0 to maxage"<<endl;
    report4<<"#Pattern:_10; parm=0; selex=1.0 for ages 1 to maxage"<<endl;
    report4<<"#Pattern:_11; parm=2; selex=1.0  for specified min-max age"<<endl;
    report4<<"#Pattern:_12; parm=2; age logistic"<<endl;
-   report4<<"#Pattern:_13; parm=8; age double logistic"<<endl;
+   report4<<"#Pattern:_13; parm=8; age double logistic. Recommend using pattern 18 instead."<<endl;
    report4<<"#Pattern:_14; parm=nages+1; age empirical"<<endl;
    report4<<"#Pattern:_15; parm=0; mirror another age or length selex"<<endl;
    report4<<"#Pattern:_16; parm=2; Coleraine - Gaussian"<<endl;


### PR DESCRIPTION
## What issue(s) does this PR address? Describe and add issue numbers, if applicable.

#228 

This pull requests adds or edits warnings and exit statements for selectivity patterns that have been discontinued or are not recommended.

- [x] Link issue on pull request

## What tests have been done? Upload any model input files created for testing in a zip file, if possible.

I compiled and tested out all selectivity patterns that have exits and warnings or just warnings (length patterns 2, 4, 7, 30, 8; age patterns 13, 18).  I did this by modifying the selectivity patterns and number of lines required as in the manual (note pattern says it need 8 parameter lines, but only needs 6)

## What tests/review still need to be done? Who can do it, and by when is it needed (ideally)?

It would be good for Rick to review the code. In particular, if the single warnings when the model run is not supposed to exit on error are implemented correctly and if there are any changes in wording needed.

Someone checking at least a few of the patterns would be helpful, to make sure my tests also work elsewhere. 

## Check which is true. This PR requires:

- [ ] Changes in r4ss
- [x] Changes to SS3 manual
- [x] Changes to SSI (the SS3 GUI)
- [x] An entry in the stock synthesis change log (new features, bug reports)

##  Describe any changes in r4ss/SS3 manual/SSI/change log that are needed (if checked):
### for ss3 manual

It might be good to remove the discontinued patterns from the manual; I think they have all been discontinued for years at this point. 

### for change log
Add warnings for discontinued selectivity patterns
