### PR TITLE
complete addition of TG_min_recap, and revise compreport

### DIFF
--- a/SS_objfunc.tpl
+++ b/SS_objfunc.tpl
@@ -515,21 +515,23 @@ FUNCTION void evaluate_the_objective_function()
       k=1+2*N_TG;
       for (TG=1;TG<=N_TG;TG++)
       {
-        j=TG+2*N_TG;
-        if(TG_parm_PH(j)==-1000.)
-        	{ }//  do nothing keep k at same value
-        else
-        {
-          if (TG_parm_PH(j)>-1000.)	{k=j;} else {k=-1000-TG_parm_PH(j)+2*N_TG;}
+        if(TG_use(TG)>=TG_min_recap){
+          j=TG+2*N_TG;
+          if(TG_parm_PH(j)==-1000.)
+          	{ }//  do nothing keep k at same value
+          else
+          {
+            if (TG_parm_PH(j)>-1000.)	{k=j;} else {k=-1000-TG_parm_PH(j)+2*N_TG;}
+          }
+          overdisp=TG_parm(k);
+          for (TG_t=TG_mixperiod;TG_t<=TG_endtime(TG);TG_t++)
+          {
+            TG_recap_exp(TG,TG_t)(1,Nfleet)+=1.0e-6;  // add a tiny amount
+            TG_recap_exp(TG,TG_t,0) = sum(TG_recap_exp(TG,TG_t)(1,Nfleet));
+            TG_recap_exp(TG,TG_t)(1,Nfleet)/=TG_recap_exp(TG,TG_t,0);
+            if(Nfleet>1) TG_like1(TG)-=TG_recap_obs(TG,TG_t,0)* (TG_recap_obs(TG,TG_t)(1,Nfleet) * log(TG_recap_exp(TG,TG_t)(1,Nfleet)));
+            TG_like2(TG)-=log_negbinomial_density(TG_recap_obs(TG,TG_t,0),TG_recap_exp(TG,TG_t,0),overdisp);
         }
-        overdisp=TG_parm(k);
-        for (TG_t=TG_mixperiod;TG_t<=TG_endtime(TG);TG_t++)
-        {
-          TG_recap_exp(TG,TG_t)(1,Nfleet)+=1.0e-6;  // add a tiny amount
-          TG_recap_exp(TG,TG_t,0) = sum(TG_recap_exp(TG,TG_t)(1,Nfleet));
-          TG_recap_exp(TG,TG_t)(1,Nfleet)/=TG_recap_exp(TG,TG_t,0);
-          if(Nfleet>1) TG_like1(TG)-=TG_recap_obs(TG,TG_t,0)* (TG_recap_obs(TG,TG_t)(1,Nfleet) * log(TG_recap_exp(TG,TG_t)(1,Nfleet)));
-          TG_like2(TG)-=log_negbinomial_density(TG_recap_obs(TG,TG_t,0),TG_recap_exp(TG,TG_t,0),overdisp);
         }
       }
     if(do_once==1) cout<<" did tag obj_fun "<<TG_like1<<endl<<TG_like2<<endl;

--- a/SS_readdata_330.tpl
+++ b/SS_readdata_330.tpl
@@ -2736,42 +2736,38 @@
  END_CALCS
 
 !!//  SS_Label_Info_2.12 #Read tag release and recapture data
+  int Do_TG_rd;
   int Do_TG;
   int TG;
   int N_TG   // N tag groups
   int N_TG2;
   int TG_timestart;
   int N_TG_recap;   //  N recapture events
-  int TG_mixperiod_rd;
   int TG_mixperiod; //  First period (seasons) to start comparing obs to expected recoveries; period=0 is the release period
   int TG_maxperiods; //  max number of periods (seasons) to track recoveries; period=0 is the release period
   int TG_min_recap; //  minimum number of tags recaptured to include this TG in the logL
  LOCAL_CALCS
   Do_TG=0;
-  *(ad_comm::global_datafile) >> Do_TG;
-  echoinput<<Do_TG<<" Do_TagData(0/1) "<<endl;
-  if(Do_TG>0)
+  *(ad_comm::global_datafile) >> Do_TG_rd;
+  echoinput<<Do_TG_rd<<" Do_TagData(0/1/2) "<<endl<<"#  where 2 indicates additional read of TG_min_recap"<<endl;
+  if(Do_TG_rd>0)
   {
     Do_TG=1;
     *(ad_comm::global_datafile) >> N_TG;
     *(ad_comm::global_datafile) >> N_TG_recap;
-    *(ad_comm::global_datafile) >> TG_mixperiod_rd;
+    *(ad_comm::global_datafile) >> TG_mixperiod;
     *(ad_comm::global_datafile) >> TG_maxperiods;
-    if(TG_mixperiod_rd>=0){
-      TG_mixperiod=TG_mixperiod_rd;
-      TG_min_recap=0;
-    }
-    else{
-      TG_mixperiod=-TG_mixperiod_rd;
-      *(ad_comm::global_datafile) >> TG_min_recap;
-    }
+    TG_min_recap=0;
     N_TG2=N_TG;
     TG_timestart=9999;
     echoinput<<N_TG<<" N tag groups "<<endl
     <<N_TG_recap<<" N recapture events"<<endl
     <<TG_mixperiod<<"  Latency period for mixing"<<endl
-    <<TG_maxperiods<<" N periods to track recoveries"<<endl
-    <<TG_min_recap<<" min recaps >= mixperiod for inclusion in logL"<<endl;
+    <<TG_maxperiods<<" N periods to track recoveries"<<endl;
+    if(Do_TG_rd==2){
+    *(ad_comm::global_datafile) >> TG_min_recap;
+    echoinput<<TG_min_recap<<" min recaps >= mixperiod for inclusion in logL"<<endl;
+    }
   }
   else
   {

--- a/SS_write_report.tpl
+++ b/SS_write_report.tpl
@@ -3279,8 +3279,8 @@ FUNCTION void write_bigoutput()
           SS_compout<<y<<" NA "<<s<<" NA "<<temp<<" NA "<<TG_release(TG,2)<<" "<<TG<<" "<<TG_release(TG,6)<<" TAG2 NA NA NA NA NA "<<
           // TAG2 values (total recaptures)
           // Fill in columns for: Obs Exp Pearson Nsamp_adj Nsamp_in effN Like Cum_obs Cum_exp SuprPer Used?
-          temp<<" "<<TG_recap_obs(TG,TG_t,0)<<" "<<TG_recap_exp(TG,TG_t,0)<<" NA NA NA NA NA NA NA NA ";
-          if(TG_t>=TG_mixperiod) {SS_compout<<"_"<<endl;} else {SS_compout<<" skip"<<endl;}
+          TG_t<<" "<<TG_recap_obs(TG,TG_t,0)<<" "<<TG_recap_exp(TG,TG_t,0)<<" NA NA NA NA NA NA NA NA ";
+          if(TG_t>=TG_mixperiod && TG_use(TG)>=TG_min_recap) {SS_compout<<"_"<<endl;} else {SS_compout<<" skip"<<endl;}
           // TAG1 values (proportions for each fleet) associated with the above TAG2 output
           if(Nfleet>1)
           for (f=1;f<=Nfleet;f++)
@@ -3291,7 +3291,7 @@ FUNCTION void write_bigoutput()
             f<<" "<<TG_recap_obs(TG,TG_t,f)<<" "<<TG_recap_exp(TG,TG_t,f)<<" NA "<<TG_recap_obs(TG,TG_t,0)<<" NA "
             <<" NA NA NA NA NA "; // NA values are for: effN Like Cum_obs Cum_exp SuprPer
           // Fill in Used? column
-          if(TG_t>=TG_mixperiod) {SS_compout<<"_"<<endl;} else {SS_compout<<" skip"<<endl;}
+          if(TG_t>=TG_mixperiod && TG_use(TG)>=TG_min_recap) {SS_compout<<"_"<<endl;} else {SS_compout<<" skip"<<endl;}
           }
           s++; if(s>nseas) {s=1; y++;}
         }

--- a/SS_write_ssnew.tpl
+++ b/SS_write_ssnew.tpl
@@ -335,7 +335,7 @@ FUNCTION void write_nudata()
       report1<<TG_min_recap<< " # TG_min_recap ## tag group's N recaps >=mixperiod must be >= min_recap to include tag group in logL)"<<endl;
     }
     else{
-    report1<< " # COND:  TG_min_recap ##  use Do_TG=2 to invoke reading TG_min_recap after TG_maxperiods"<<endl;
+    report1<< "# COND:  TG_min_recap ##  use Do_TG=2 to invoke reading TG_min_recap after TG_maxperiods"<<endl;
     }
 
     // tag releases

--- a/SS_write_ssnew.tpl
+++ b/SS_write_ssnew.tpl
@@ -329,8 +329,15 @@ FUNCTION void write_nudata()
     // info on dimensions of tagging data
     report1<<N_TG<<" # N tag groups"<<endl;
     report1<<N_TG_recap<<" # N recap events"<<endl;
-    report1<<TG_mixperiod<<" # mixing latency period: N periods to delay before comparing observed to expected recoveries (0 = release period)"<<endl;
-    report1<<TG_maxperiods<<" # max periods (seasons) to track recoveries, after which tags enter accumulator"<<endl;
+    report1<<TG_mixperiod_rd<<" # TG_mixperiod (latency) is the first period in which logL is calculated for this tag group (0 = release period)"<<endl;
+    report1<<"#  (use negative value for TG_mixperiod to invoke reading TG_min_recap after TG_maxperiods"<<endl;
+    report1<<TG_maxperiods<<" # max periods (seasons) to track recoveries, after which tags are still read into this accumulator period"<<endl;
+    if(TG_mixperiod_rd>=0){
+      report1<<"#  TG_min_recap would go here if TG_mixperiod < 0"<<endl;
+    }
+    else{
+      report1<<TG_min_recap<<" # TG_min_recap:  N recaps >= mixperiod must be >= min_recap to include tag group in logL"<<endl;
+    }
 
     // tag releases
     report1<<"# Release data for each tag group.  Tags are considered to be released at the beginning of a season (period)"<<endl;

--- a/SS_write_ssnew.tpl
+++ b/SS_write_ssnew.tpl
@@ -323,20 +323,19 @@ FUNCTION void write_nudata()
   }
 
   // begin tagging data section #1 (observed data)
-  report1<<"#"<<endl<<Do_TG<<" # do tags (0/1)"<<endl;
-  if(Do_TG>0)
+  report1<<"# "<<endl<<Do_TG_rd<<" # do tags (0/1/2); where 2 allows entry of TG_min_recap"<<endl;
+  if(Do_TG_rd>0)
   {
     // info on dimensions of tagging data
     report1<<N_TG<<" # N tag groups"<<endl;
     report1<<N_TG_recap<<" # N recap events"<<endl;
-    report1<<TG_mixperiod_rd<<" # TG_mixperiod (latency) is the first period in which logL is calculated for this tag group (0 = release period)"<<endl;
-    report1<<"#  (use negative value for TG_mixperiod to invoke reading TG_min_recap after TG_maxperiods"<<endl;
-    report1<<TG_maxperiods<<" # max periods (seasons) to track recoveries, after which tags are still read into this accumulator period"<<endl;
-    if(TG_mixperiod_rd>=0){
-      report1<<"#  TG_min_recap would go here if TG_mixperiod < 0"<<endl;
+    report1<<TG_mixperiod<<" # TG_mixperiod ## (latency) is the first period in which logL is calculated for this tag group (0 = release period)"<<endl;
+    report1<<TG_maxperiods<<  " # max periods ##  to track recaptures (units=seasons), after which tags are still read into this accumulator period"<<endl;
+    if(Do_TG_rd==2){
+      report1<<TG_min_recap<< " # TG_min_recap ## tag group's N recaps >=mixperiod must be >= min_recap to include tag group in logL)"<<endl;
     }
     else{
-      report1<<TG_min_recap<<" # TG_min_recap:  N recaps >= mixperiod must be >= min_recap to include tag group in logL"<<endl;
+    report1<< " # COND:  TG_min_recap ##  use Do_TG=2 to invoke reading TG_min_recap after TG_maxperiods"<<endl;
     }
 
     // tag releases


### PR DESCRIPTION
## What issue(s) does this PR address? Describe and add issue numbers, if applicable.
This adds capability to exclude from the tag logL tag groups with less than a specified minimum number of recaptures
- [#280  ] Link issue on pull request

## What tests have been done? Upload any model input files created for testing in a zip file, if possible.
works with the IOTC Yellowfin tuna spatial model
## What tests/review still need to be done? Who can do it, and by when is it needed (ideally)?
none
## Check which is true. This PR requires:

- [X] Changes in r4ss
- [X] Changes to SS3 manual
- [X] Changes to SSI (the SS3 GUI)
- [X] An entry in the stock synthesis change log (new features, bug reports)

##  Describe any changes in r4ss/SS3 manual/SSI/change log that are needed (if checked):
input of new feature is conditional on TG_mixperiod having a negative value:
1 # do tags (0/1)
121 # N tag groups
769 # N recap events
-4 # TG_mixperiod (latency) is the first period in which logL is calculated for this tag group (0 = release period)
#  (use negative value for TG_mixperiod to invoke reading TG_min_recap after TG_maxperiods
16 # max periods (seasons) to track recoveries, after which tags are still read into this accumulator period
2 # TG_min_recap:  N recaps >= mixperiod must be >= min_recap to include tag group in logL

## Additional information (optional):
@jyqalan