### PR TITLE
fix, #298: add conditional statement around bmark code

### DIFF
--- a/SS_popdyn.tpl
+++ b/SS_popdyn.tpl
@@ -344,16 +344,15 @@ FUNCTION void get_initial_conditions()
     SSB_virgin = SSB_equil;
     SPR_virgin = SSB_equil / Recr_virgin; //  spawners per recruit
   
-    //  unnecessary because these are now done in benchmark itself
-    //    if(Do_Benchmark==0)
-    //    {
-    //      Mgmt_quant(1)=SSB_virgin;
-    //      SSB_unf=SSB_virgin;
-    //      Recr_unf=Recr_virgin;
-    //      Mgmt_quant(2)=totbio;  //  from equil calcs
-    //      Mgmt_quant(3)=smrybio;  //  from equil calcs
-    //      Mgmt_quant(4)=Recr_virgin;
-    //    }
+        if(Do_Benchmark==0)
+        {
+          Mgmt_quant(1)=SSB_virgin;
+          SSB_unf=SSB_virgin;
+          Recr_unf=Recr_virgin;
+          Mgmt_quant(2)=totbio;  //  from equil calcs
+          Mgmt_quant(3)=smrybio;  //  from equil calcs
+          Mgmt_quant(4)=Recr_virgin;
+        }
   
     Smry_Table(styr - 2, 1) = totbio; //  from equil calcs
     Smry_Table(styr - 2, 2) = smrybio; //  from equil calcs

--- a/SS_proced.tpl
+++ b/SS_proced.tpl
@@ -148,8 +148,11 @@ PROCEDURE_SECTION
       get_initial_conditions();
       get_time_series(); //  in write_big_report
       evaluate_the_objective_function();
-      setup_Benchmark();
-      Get_Benchmarks(show_MSY);
+      if (Do_Benchmark > 0)
+      {
+        setup_Benchmark();
+        Get_Benchmarks(show_MSY);
+      }
   
       //  SS_Label_Info_7.6.2 #Call fxn Get_Forecast()
       if (Do_Forecast > 0)

--- a/SS_write_report.tpl
+++ b/SS_write_report.tpl
@@ -1034,7 +1034,7 @@ FUNCTION void write_bigoutput()
       settle_time = settle_assignments_timing(settle);
       SS2out << settle << " " << settle_time << " " << gp << " " << p << " " << Settle_month(settle_time) << " " << Settle_seas(settle_time) << " " << Settle_age(settle_time) << " " << Settle_timing_seas(settle_time) << " " << recr_dist_endyr(gp, settle_time, p) << endl;
     }
-  
+    SS2out << "#" << endl;
     SS2out << "RECRUITMENT_DIST_TIMESERIES" << endl
            << "Year settle_assignment" << endl;
     SS2out << "Year ";


### PR DESCRIPTION
## What issue(s) does this PR address? Describe and add issue numbers, if applicable.

Link issue(s) here: #298 

## What tests have been done? Upload any model input files created for testing in a zip file, if possible.

I tested with the two morphs model (attached), compiled SS3 locally, and ran with no options. The nan message disappeared, however there was a covariance matrix may not be positive definite warning. I'm not sure if this has something to do with the SS3 code, or if it is specific to the model.

[two_morph.zip](https://github.com/nmfs-stock-synthesis/stock-synthesis/files/8563411/two_morph.zip)

## What tests/review still need to be done? Who can do it, and by when is it needed (ideally)?

If @Rick-Methot-NOAA could take a look and make sure this fix does what I think it does, that would be great!

## Check which is true. This PR requires:

- [x] no further changes to r4ss
- [x] no further changes to the manual
- [x] no further changes to SSI (the SS3 GUI)
- [ ] no further changes to the stock synthesis change log (new features, bug reports)

## Describe any changes in r4ss/SS3 manual/SSI/change log that are needed (if not checked):

Add line in the change log about this bug.

## Additional information (optional):
