### PR TITLE
#321: use exit(1) instead of abort()

### DIFF
--- a/SS_readcontrol_330.tpl
+++ b/SS_readcontrol_330.tpl
@@ -4637,8 +4637,8 @@
   }
   else
   {
-  cout<<" Unsuccessful end of control file, SS will abort. check echoinput for clues.  Last read is: "<<fim<<endl;
-  abort();
+  cout<<" Unsuccessful end of control file. Check echoinput for clues.  Last read is: "<<fim<<endl;
+  exit(1);
   }
  END_CALCS
 


### PR DESCRIPTION
## What issue(s) does this PR address? Describe and add issue numbers, if applicable.

Link issue(s) here: #321

## What tests have been done? Upload any model input files created for testing in a zip file, if possible.
None, because this change is very simple. Given we use exit(1) elsewhere in the code, it doesn't seem necessary to test this small change.

## What tests/review still need to be done? Who can do it, and by when is it needed (ideally)?
@Rick-Methot-NOAA to review the change and "approve" it or request edits.

## Check which is true. This PR requires:

- [x] no further changes to r4ss
- [x] no further changes to the manual
- [x] no further changes to SSI (the SS3 GUI)
- [ ] no further changes to the stock synthesis change log (new features, bug reports)

## Describe any changes in r4ss/SS3 manual/SSI/change log that are needed (if not checked):
Not sure if this change is worth documenting in the change log? It's really small.

## Additional information (optional):
