### PR TITLE
Fix: remove warnings coming from ss3 source code. Details below

### DIFF
--- a/.github/workflows/call-build-ss3-warnings.yml
+++ b/.github/workflows/call-build-ss3-warnings.yml
@@ -13,4 +13,4 @@ on:
       - main
 jobs:
   call-workflow:
-    uses: nmfs-stock-synthesis/workflows/.github/workflows/build-ss3-warnings.yml@main
+    uses: nmfs-stock-synthesis/workflows/.github/workflows/build-ss3-warnings.yml@lower_warning_count

--- a/SS_global.tpl
+++ b/SS_global.tpl
@@ -295,10 +295,23 @@ GLOBALS_SECTION
   }
 
 // SS_Label_Function_xxxx  #create_timevary()  called by readdata to create timevary parameters
+  /*
+   where:
+   baseparm_list:           vector with the base parameter which has some type of timevary characteristic
+   timevary_setup:        vector which contains specs of all types of timevary  for this base parameter
+                          will be pushed to timevary_def cumulative across all types of base parameters
+   timevary_byyear:        vector containing column(timevary_MG,mgp_type(j)), will be modified in create_timevary
+   autogen_timevary:      switch to autogenerate or not
+   targettype:           integer with type of MGparm being worked on; analogous to 2*fleet in the selectivity section
+   block_design_pass:       block design, if any, being used
+   env_data_pass:           matrix containing entire set of environmental data as read
+   N_parm_dev:            integer that is incremented in create_timevary as dev vectors are created; cumulative across all types of parameters
+   finish_starter:  End of starter file value
+  */
   void create_timevary(dvector& baseparm_list, ivector& timevary_setup,
     ivector& timevary_byyear, int& autogen_timevary, const int& targettype,
-    const ivector& block_design_pass, const int& parm_adjust_method,
-    const dvector& env_data_pass, int& N_parm_dev, const double& finish_starter)
+    const ivector& block_design_pass, const dvector& env_data_pass, 
+    int& N_parm_dev, const double& finish_starter)
   {
   //  where timevary_byyear is a selected column of a year x type matrix (e.g. timevary_MG) in read_control
   //  timevary_setup(1)=baseparm type;
@@ -1090,7 +1103,7 @@ REPORT_SECTION
   int k1 = parm_gradients.size();
   if (k1 < k)
     k = k1;
-  for (unsigned i = 1; i <= k; i++)
+  for (int i = 1; i <= k; i++)
     parm_gradients(i) = gradients(i);
   if (current_phase() >= max_phase && finished_minimize == 0)
     finished_minimize = 1; //  because REPORT occurs after minimize finished

--- a/SS_objfunc.tpl
+++ b/SS_objfunc.tpl
@@ -355,10 +355,10 @@ FUNCTION void evaluate_the_objective_function()
               }
               else //  dirichlet
               {
-                // from Thorson:  NLL -= gammln(A) - gammln(ninput_t(t)+A) + sum(gammln(ninput_t(t)*extract_row(pobs_ta,t) + A*extract_row(pexp_ta,t))) - sum(lgamma(A*extract_row(pexp_ta,t))) \
-//        dirichlet_Parm=mfexp(selparm(Comp_Err_Parm_Start+Comp_Err_L2(f)))*nsamp_l(f,i);
-                // in option 1, dirichlet_Parm = Theta*n from equation (10) of Thorson et al. 2016
-                // in option 2, dirichlet_Parm = Beta from equation (4) of Thorson et al. 2016
+                /* from Thorson:  NLL -= gammln(A) - gammln(ninput_t(t)+A) + sum(gammln(ninput_t(t)*extract_row(pobs_ta,t) + A*extract_row(pexp_ta,t))) - sum(lgamma(A*extract_row(pexp_ta,t))) \
+                dirichlet_Parm=mfexp(selparm(Comp_Err_Parm_Start+Comp_Err_L2(f)))*nsamp_l(f,i);
+                in option 1, dirichlet_Parm = Theta*n from equation (10) of Thorson et al. 2016
+                in option 2, dirichlet_Parm = Beta from equation (4) of Thorson et al. 2016 */
                 if (Comp_Err_L(f) == 1)
                   dirichlet_Parm = mfexp(selparm(Comp_Err_Parm_Start + Comp_Err_L2(f))) * nsamp_l(f, i);
                 if (Comp_Err_L(f) == 2)
@@ -492,10 +492,11 @@ FUNCTION void evaluate_the_objective_function()
               }
               else // dirichlet
               {
-                // from Thorson:  NLL -= gammln(A) - gammln(ninput_t(t)+A) + sum(gammln(ninput_t(t)*extract_row(pobs_ta,t) + A*extract_row(pexp_ta,t))) - sum(lgamma(A*extract_row(pexp_ta,t))) \
-//              dirichlet_Parm=mfexp(selparm(Comp_Err_Parm_Start+Comp_Err_A2(f)))*nsamp_a(f,i);
-                // in option 1, dirichlet_Parm = Theta*n from equation (10) of Thorson et al. 2016
-                // in option 2, dirichlet_Parm = Beta from equation (4) of Thorson et al. 2016
+                /* from Thorson:  NLL -= gammln(A) - gammln(ninput_t(t)+A) + sum(gammln(ninput_t(t)*extract_row(pobs_ta,t) + A*extract_row(pexp_ta,t))) - sum(lgamma(A*extract_row(pexp_ta,t))) \
+                   dirichlet_Parm=mfexp(selparm(Comp_Err_Parm_Start+Comp_Err_A2(f)))*nsamp_a(f,i);
+                in option 1, dirichlet_Parm = Theta*n from equation (10) of Thorson et al. 2016
+                in option 2, dirichlet_Parm = Beta from equation (4) of Thorson et al. 2016
+                */
                 if (Comp_Err_A(f) == 1)
                   dirichlet_Parm = mfexp(selparm(Comp_Err_Parm_Start + Comp_Err_A2(f))) * nsamp_a(f, i);
                 if (Comp_Err_A(f) == 2)

--- a/SS_readcontrol_330.tpl
+++ b/SS_readcontrol_330.tpl
@@ -1466,25 +1466,12 @@
        {
          if(z>N_Block_Designs)
           {N_warn++; cout<<"Fatal_input_error, see warning"<<endl;  warning<<N_warn<<" "<<"MG block request exceeds N_block patterns"<<endl;  exit(1);}
-         create_timevary(MGparm_1(j),timevary_setup, timevary_pass, autogen_timevary(timevary_setup(1)), mgp_type(j), Block_Design(z), parm_adjust_method, env_data_pass, N_parm_dev,finish_starter);
+         create_timevary(MGparm_1(j),timevary_setup, timevary_pass, autogen_timevary(timevary_setup(1)), mgp_type(j), Block_Design(z), env_data_pass, N_parm_dev,finish_starter);
        }
        else
        {
-         create_timevary(MGparm_1(j),timevary_setup, timevary_pass, autogen_timevary(timevary_setup(1)), mgp_type(j), block_design_null, parm_adjust_method, env_data_pass, N_parm_dev,finish_starter);
+         create_timevary(MGparm_1(j),timevary_setup, timevary_pass, autogen_timevary(timevary_setup(1)), mgp_type(j), block_design_null, env_data_pass, N_parm_dev,finish_starter);
        }
-  /*
-   where:
-   MGparm_1(j):           vector with the base parameter which has some type of timevary characteristic
-   timevary_setup:        vector which contains specs of all types of timevary  for this base parameter
-                          will be pushed to timevary_def cumulative across all types of base parameters
-   timevary_pass:        vector containing column(timevary_MG,mgp_type(j)), will be modified in create_timevary
-   autogen_timevary:      switch to autogenerate or not
-   mgp_type(j):           integer with type of MGparm being worked on; analogous to 2*fleet in the selectivity section
-   Block_Design(z):       block design, if any, being used
-   parm_adjust_method:    switch to determine if adjusted parameter will stay in bounds; used to create warnings in create_timevary
-   env_data_RD:           matrix containing entire set of environmental data as read
-   N_parm_dev:            integer that is incremented in create_timevary as dev vectors are created; cumulative across all types of parameters
-  */
        timevary_def.push_back (timevary_setup(1,14));
        for(y=styr-3;y<=YrMax+1;y++) {timevary_MG(y,mgp_type(j))=timevary_pass(y);}  // year vector for this category of MGparm
        if(j==MGP_CGD) CGD_onoff=1;
@@ -1779,24 +1766,12 @@
        {
          if(SR_parm_1(j,13)>N_Block_Designs)
           {N_warn++; cout<<"Fatal_input_error, see warning"<<endl;  warning<<N_warn<<" "<<"SR block request exceeds N_block patterns"<<endl;  exit(1);}
-         create_timevary(SR_parm_1(j),timevary_setup, timevary_pass, autogen_timevary(timevary_setup(1)), f, Block_Design(SR_parm_1(j,13)), parm_adjust_method, env_data_pass, N_parm_dev,finish_starter);
+         create_timevary(SR_parm_1(j),timevary_setup, timevary_pass, autogen_timevary(timevary_setup(1)), f, Block_Design(SR_parm_1(j,13)), env_data_pass, N_parm_dev,finish_starter);
        }
        else
        {
-         create_timevary(SR_parm_1(j),timevary_setup, timevary_pass, autogen_timevary(timevary_setup(1)), f, block_design_null, parm_adjust_method, env_data_pass, N_parm_dev,finish_starter);
+         create_timevary(SR_parm_1(j),timevary_setup, timevary_pass, autogen_timevary(timevary_setup(1)), f, block_design_null, env_data_pass, N_parm_dev,finish_starter);
        }
-  /*
-   where:
-   SR_parm_1(j):           vector with the base parameter which has some type of timevary characteristic
-   timevary_setup:        vector which contains specs of all types of timevary  for this base parameter
-                          will be pushed to timevary_def cumulative across all types of base parameters
-   timevary_pass:        vector containing column(timevary_MG,mgp_type(j)), will be modified in create_timevary
-   autogen_timevary:      switch to autogenerate or not
-   block_design(z):       block design, if any, being used
-   parm_adjust_method:    switch to determine if adjusted parameter will stay in bounds; used to create warnings in create_timevary
-   env_data_RD:           matrix containing entire set of environmental data as read
-   N_parm_dev:            integer that is incremented in create_timevary as dev vectors are created; cumulative across all types of parameters
-  */
        timevary_def.push_back (timevary_setup(1,14));
        for(y=styr-3;y<=YrMax+1;y++) {timevary_SRparm(y)=timevary_pass(y);}  // year vector for this category og MGparm
      }
@@ -2676,26 +2651,12 @@
        {
          if(Q_parm_1(j,13)>N_Block_Designs)
           {N_warn++; cout<<"Fatal_input_error, see warning"<<endl;  warning<<N_warn<<" "<<" Error: Q block request exceeds N_block patterns"<<endl;  exit(1);}
-         create_timevary(Q_parm_1(j),timevary_setup, timevary_pass, autogen_timevary(timevary_setup(1)), f, Block_Design(Q_parm_1(j,13)), parm_adjust_method, env_data_pass, N_parm_dev,finish_starter);
+         create_timevary(Q_parm_1(j),timevary_setup, timevary_pass, autogen_timevary(timevary_setup(1)), f, Block_Design(Q_parm_1(j,13)), env_data_pass, N_parm_dev,finish_starter);
        }
        else
        {
-         create_timevary(Q_parm_1(j),timevary_setup, timevary_pass, autogen_timevary(timevary_setup(1)), f, block_design_null, parm_adjust_method, env_data_pass, N_parm_dev,finish_starter);
+         create_timevary(Q_parm_1(j),timevary_setup, timevary_pass, autogen_timevary(timevary_setup(1)), f, block_design_null, env_data_pass, N_parm_dev,finish_starter);
        }
-  /*
-   where:
-   Q_parm_1(j):           vector with the base parameter which has some type of timevary characteristic
-   timevary_setup:        vector which contains specs of all types of timevary  for this base parameter
-                          will be pushed to timevary_def cumulative across all types of base parameters
-   timevary_pass:        vector containing column(timevary_MG,mgp_type(j)), will be modified in create_timevary
-   autogen_timevary:      switch to autogenerate or not
-   f:           integer with type of MGparm being worked on; analogous to 2*fleet in the selectivity section
-   block_design(z):       block design, if any, being used
-   parm_adjust_method:    switch to determine if adjusted parameter will stay in bounds; used to create warnings in create_timevary
-   env_data_RD:           matrix containing entire set of environmental data as read
-   N_parm_dev:            integer that is incremented in create_timevary as dev vectors are created; cumulative across all types of parameters
-  */
-
        timevary_def.push_back (timevary_setup(1,14));
        for(y=styr-3;y<=YrMax+1;y++) {timevary_Qparm(y,f)=timevary_pass(y);}  // year vector for this category og MGparm
      }
@@ -3559,25 +3520,12 @@
        {
          if(z>N_Block_Designs)
           {N_warn++; cout<<"Fatal_input_error, see warning"<<endl;  warning<<N_warn<<" "<<" error: selex block request exceeds N_block patterns"<<endl;  exit(1);}
-         create_timevary(selparm_1(j),timevary_setup, timevary_pass, autogen_timevary(timevary_setup(1)), selparm_fleet(j), Block_Design(z), parm_adjust_method, env_data_pass, N_parm_dev,finish_starter);
+         create_timevary(selparm_1(j),timevary_setup, timevary_pass, autogen_timevary(timevary_setup(1)), selparm_fleet(j), Block_Design(z), env_data_pass, N_parm_dev,finish_starter);
        }
        else
        {
-         create_timevary(selparm_1(j),timevary_setup, timevary_pass, autogen_timevary(timevary_setup(1)), selparm_fleet(j), block_design_null, parm_adjust_method, env_data_pass, N_parm_dev,finish_starter);
+         create_timevary(selparm_1(j),timevary_setup, timevary_pass, autogen_timevary(timevary_setup(1)), selparm_fleet(j), block_design_null, env_data_pass, N_parm_dev,finish_starter);
        }
-  /*
-   where:
-   selparm_1(j):           vector with the base parameter which has some type of timevary characteristic
-   timevary_setup:        vector which contains specs of all types of timevary  for this base parameter
-                          will be pushed to timevary_def cumulative across all types of base parameters
-   timevary_pass:        vector containing column(timevary_MG,mgp_type(j)), will be modified in create_timevary
-   autogen_timevary:      switch to autogenerate or not
-   selparm_fleet(j):           integer with type of MGparm being worked on; analogous to 2*fleet in the selectivity section
-   block_design(z):       block design, if any, being used
-   parm_adjust_method:    switch to determine if adjusted parameter will stay in bounds; used to create warnings in create_timevary
-   env_data_RD:           matrix containing entire set of environmental data as read
-   N_parm_dev:            integer that is incremented in create_timevary as dev vectors are created; cumulative across all types of parameters
-  */
        timevary_def.push_back (timevary_setup(1,14));
        for(y=styr-3;y<=YrMax+1;y++) {timevary_sel(y,selparm_fleet(j))=timevary_pass(y);}  // year vector for this category
      }

--- a/SS_readdata_330.tpl
+++ b/SS_readdata_330.tpl
@@ -526,7 +526,7 @@
     if(totcat(y)>0.0 && first_catch_yr==0) first_catch_yr=y;
     if(y==endyr && totcat(y)==0.0)
     {
-      N_warn++;  warning<<N_warn<<" catch is 0.0 in endyr; this can cause problem in the benchmark and forecast calculations"<<endl;
+      N_warn++;  warning<<N_warn<<" catch is 0.0 in endyr; this can cause problem in the benchmark and forecast calculations. "<<endl;
     }
   }
     echoinput<<endl<<"#_show_total_catch_by_fleet"<<endl;

--- a/SS_selex.tpl
+++ b/SS_selex.tpl
@@ -254,6 +254,7 @@ FUNCTION void get_selectivity()
               // #43 non-parametric size selex scaled by average of values at low bin through high bin
               case 43:
                 scaling_offset = 2;
+                [[fallthrough]];
               case 6:
               {
                 lastsel = -10.0; // log(selex) for first bin;
@@ -600,6 +601,7 @@ FUNCTION void get_selectivity()
               /*  uses max(raw vector) to achieve scale to 1.0 */
               case 42:
                 scaling_offset = 2;
+                [[fallthrough]];
               case 27:
               {
                 int j2;
@@ -1139,6 +1141,7 @@ FUNCTION void get_selectivity()
               //    transformation as selex=exp(parm); some special codes */
               case 41:
                 scaling_offset = 2;
+                [[fallthrough]];
               case 17: //
               {
                 lastsel = 0.0; //  value is the change in log(selex);  this is the reference value for age 0
@@ -1533,6 +1536,7 @@ FUNCTION void get_selectivity()
               // #42 cubic spline scaled by average of values at low age through high age
               case 42:
                 scaling_offset = 2;
+                [[fallthrough]];
               case 27:
               {
                 // define vectors which form the basis for cubic spline selectivity

--- a/SS_write_report.tpl
+++ b/SS_write_report.tpl
@@ -2180,11 +2180,8 @@ FUNCTION void write_bigoutput()
         dvector tempvec_l(1, exp_l(f, i).size());
         tempvec_l = value(exp_l(f, i));
         more_comp_info = process_comps(gender, gen_l(f, i), len_bins_dat2, len_bins_dat_m2, tails_l(f, i), obs_l(f, i), tempvec_l);
-        if (Comp_Err_L(f) == 0) // multinomial
-        {
-          Nsamp_DM = nsamp_l(f, i); // not used
-        }
-        else if (Comp_Err_L(f) == 1) //  Dirichlet #1
+        Nsamp_DM = Nsamp_adj; // Will remain this if not used
+        if (Comp_Err_L(f) == 1) //  Dirichlet #1
         {
           dirichlet_Parm = mfexp(selparm(Comp_Err_Parm_Start + Comp_Err_L2(f))); //  Thorson's theta fro eq 10
           // effN_DM = 1/(1+theta) + n*theta/(1+theta)
@@ -2328,11 +2325,8 @@ FUNCTION void write_bigoutput()
         tempvec_a = value(exp_a(f, i));
         more_comp_info = process_comps(gender, gen_a(f, i), age_bins, age_bins_mean, tails_a(f, i), obs_a(f, i), tempvec_a);
 
-        if (Comp_Err_A(f) == 0) // multinomial
-        {
-          Nsamp_DM = nsamp_a(f, i);
-        }
-        else if (Comp_Err_A(f) == 1) //  Dirichlet #1
+        Nsamp_DM = Nsamp_adj; // Will stay at this val for multinomial
+        if (Comp_Err_A(f) == 1) //  Dirichlet #1
         {
           dirichlet_Parm = mfexp(selparm(Comp_Err_Parm_Start + Comp_Err_A2(f))); //  Thorson's theta fro eq 10
           // effN_DM = 1/(1+theta) + n*theta/(1+theta)
@@ -4725,7 +4719,6 @@ FUNCTION void Global_MSY()
   {
   // REPORT_KEYWORD 55 GLOBAL_MSY
   //  GLOBAL_MSY with knife-edge age selection, then slot-age selection
-  int bio_t_base;
   SS2out << endl
          << pick_report_name(55) << endl;
   y = styr - 3; //  stores the averaged
@@ -4733,7 +4726,6 @@ FUNCTION void Global_MSY()
   bio_yr = y;
   eq_yr = y;
   t_base = y + (y - styr) * nseas - 1;
-  bio_t_base = styr + (bio_yr - styr) * nseas - 1;
 
   for (int MSY_loop = 0; MSY_loop <= 2; MSY_loop++)
   {

--- a/SS_write_ssnew.tpl
+++ b/SS_write_ssnew.tpl
@@ -2159,7 +2159,7 @@ FUNCTION void write_nucontrol()
     report4 << "# read list of fleets that do F as parameter; unlisted fleets stay hybrid, bycatch fleets must be included with start_PH=1, high F fleets should switch early" << endl;
     report4 << "# (A) fleet, (B) F_starting_value (used if start_PH=1), (C) start_PH for parms (99 to stay in hybrid, <0 to stay at starting value)" << endl;
     report4 << "# (A) (B) (C)  (terminate list with -9999 for fleet)" << endl;
-    for (int j = 1; j <= F_Method_4_input.size() - 2; j++)
+    for (unsigned j = 1; j <= F_Method_4_input.size() - 2; j++)
     {
       report4 << F_Method_4_input[j] << " # " << fleetname(F_Method_4_input[j](1)) << endl;
     }


### PR DESCRIPTION
## What issue(s) does this PR address? Describe and add issue numbers, if applicable.
Issue was not created, but while working on #123, it became clear to me that some of the warning messages coming from SS3 could be taken care of. This will make it easier to identify new/different warnings in the future using github actions, and also cleans up the codebase a bit. In particular, the changes made are:

- add fallthrough statement to note implicit fallthrough is intentional
- get rid of maybe uninit warning
- use multiline comment instead of single line comment to get rid of warning
- remove parm_adjust_method from create_timevary because unused
- refactor: clean up comments for time varying so only in 1 place (no warning but found while getting rid of parm_adjust_method)
- try to fix warning re using wrong type in for statements
- use int instead of unsigned
- remove unused variable bio_t_base_from function


Link issue(s) here: n/a

## What tests have been done? Upload any model input files created for testing in a zip file, if possible.
periodically, pushed changes to github and checked that the change got rid of the warning using github actions run (note: squashed commits to simplify the PR).

## What tests/review still need to be done? Who can do it, and by when is it needed (ideally)?
@Rick-Methot-NOAA should check that none of the changes to fix the warnings are problematic.

Also, Check with the github action that the only remaining warnings are marked as [-Wdeprecated-copy] remain. 

I think some work that needs to be done before merging this in is revising the github action (probably in a branch in the workflow repository), so that it can do this same check automatically. The number of warnings expected will also be less than previously expected. I can work on this once Rick verifies the changes are not problematic.

## Check which is true. This PR requires:

- [x] no further changes to r4ss
- [x] no further changes to the manual
- [x] no further changes to SSI (the SS3 GUI)
- [ ] no further changes to the stock synthesis change log (new features, bug reports)

## Describe any changes in r4ss/SS3 manual/SSI/change log that are needed (if not checked):

## Additional information (optional):
