### PR TITLE
Use virgin instead of 0 in depletion settings

### DIFF
--- a/SS_write_ssnew.tpl
+++ b/SS_write_ssnew.tpl
@@ -1418,7 +1418,7 @@ FUNCTION void write_nucontrol()
   NuStart << final_conv << " # final convergence criteria (e.g. 1.0e-04) " << endl;
   NuStart << retro_yr - endyr << " # retrospective year relative to end year (e.g. -4)" << endl;
   NuStart << Smry_Age << " # min age for calc of summary biomass" << endl;
-  NuStart << depletion_basis_rd << " # Depletion basis:  denom is: 0=skip; 1=rel X*SPB0; 2=rel SPBmsy; 3=rel X*SPB_styr; 4=rel X*SPB_endyr; values; >=11 invoke N multiyr (up to 9!) with 10's digit; >100 invokes log(ratio)" << endl;
+  NuStart << depletion_basis_rd << " # Depletion basis:  denom is: 0=skip; 1=rel X*SPBvirgin; 2=rel SPBmsy; 3=rel X*SPB_styr; 4=rel X*SPB_endyr; values; >=11 invoke N multiyr (up to 9!) with 10's digit; >100 invokes log(ratio)" << endl;
   NuStart << depletion_level << " # Fraction (X) for Depletion denominator (e.g. 0.4)" << endl;
   NuStart << SPR_reporting << " # SPR_report_basis:  0=skip; 1=(1-SPR)/(1-SPR_tgt); 2=(1-SPR)/(1-SPR_MSY); 3=(1-SPR)/(1-SPR_Btarget); 4=rawSPR" << endl;
   NuStart << F_reporting << " # F_reporting_units: 0=skip; 1=exploitation(Bio); 2=exploitation(Num); 3=sum(Apical_F's); 4=true F for range of ages; 5=unweighted avg. F for range of ages" << endl;


### PR DESCRIPTION
## What issue(s) does this PR address? 
(note: including the keyword "resolves" means the issue will be closed automatically when merged in.)
This changes the depletion setting line in starter.ss_new to read SPBvirgin instead of SPB0 for option 1, which clarifies that the virgin biomass is used and not unfished biomass.

Link issue(s), replacing everything in `[ ]`: n/a

## Describe the issue, if not included in the PR

## What tests have been done? Upload any model input files created for testing in a zip file, if possible.

n/a

## What tests/review still need to be done? Who can do it, and by when is it needed (ideally)?
n/a 
## Check which is true. This PR requires:

- [x] no further changes to r4ss
- [ ] no further changes to the manual
- [x] no further changes to SSI (the SS3 GUI)
- [x] no further changes to the stock synthesis change log (new features, bug reports)

## Describe any changes in r4ss/SS3 manual/SSI that are needed (if not checked):

Change the wording in the manual 

## If changes are needed in the change log, please fill in the table here:

Version | Date       | Description               | Issue        | Input change | Action                | Topic                                     | Type  |
| ----- | ---------- | ---------------------- | ------------ | ------------ | --------------------- | ----------------------------------------- | --------------------------------------- |
3.30.20 | [Add date] | [add concise description] | #[add issue] | [yes or no]  | [fix, new, or revise] | [e.g., biology. Use issue label options.] | [input, output, and/or calc, or ALL] |


## Additional information (optional):
