### PR TITLE
clean up and add comments for mat_fec calcs

### DIFF
--- a/SS_biofxn.tpl
+++ b/SS_biofxn.tpl
@@ -1569,7 +1569,7 @@ FUNCTION void get_mat_fec();
           if (do_once == 1)
           echoinput << "fecundity option: " << Fecund_Option << " parms: " << wtlen_p(GPat)(5, 6) << endl;
           // fec_len should only get calculated in maturity option = 1, 2, 3, or 6
-          // maturity option 4 and 6 bypass maturity and read empirical fecundity-at-age
+          // maturity option 4 and 5 bypass maturity and read empirical fecundity-at-age
 
           switch (Fecund_Option)
           {

--- a/SS_biofxn.tpl
+++ b/SS_biofxn.tpl
@@ -1557,62 +1557,71 @@ FUNCTION void get_mat_fec();
       if (WTage_rd == 1)
       {
         fec(g) = Wt_Age_t(t, -2, g);
+        make_mature_numbers(g)(First_Mature_Age, nages) = 1.0;
+        //  all other vectors set to contant value of 0.5
       }
       else
-      { // make fecundity from biology
-
-        if (do_once == 1)
-          echoinput << "fecundity option: " << Fecund_Option << " parms: " << wtlen_p(GPat)(5, 6) << endl;
-
-        switch (Fecund_Option)
+      {
+        if (do_fec_len == 1)
         {
-          case 1: // as eggs/kg (SS original configuration)
+          // make fecundity from biology
+
+          if (do_once == 1)
+          echoinput << "fecundity option: " << Fecund_Option << " parms: " << wtlen_p(GPat)(5, 6) << endl;
+          // fec_len should only get calculated in maturity option = 1, 2, 3, or 6
+          // maturity option 4 and 6 bypass maturity and read empirical fecundity-at-age
+
+          switch (Fecund_Option)
           {
-            fec_len(gp) = wtlen_p(GPat, 5) + wtlen_p(GPat, 6) * wt_len(s, gp);
-            fec_len(gp) = elem_prod(wt_len(s, gp), fec_len(gp));
-            break;
-          }
-          case 2:
-          { // as eggs = f(length)
-            fec_len(gp) = wtlen_p(GPat, 5) * pow(len_bins_m, wtlen_p(GPat, 6));
-            break;
-          }
-          case 3:
-          { // as eggs = f(body weight)
-            fec_len(gp) = wtlen_p(GPat, 5) * pow(wt_len(s, gp), wtlen_p(GPat, 6));
-            break;
-          }
-          case 4:
-          { // as eggs = a + b*Len
-            fec_len(gp) = wtlen_p(GPat, 5) + wtlen_p(GPat, 6) * len_bins_m;
-            if (wtlen_p(GPat, 5) < 0.0)
+            case 1: // as eggs/kg (SS original configuration)
             {
-              z = 1;
-              while (fec_len(gp, z) < 0.0)
-              {
-                fec_len(gp, z) = 0.0;
-                z++;
-              }
+              fec_len(gp) = wtlen_p(GPat, 5) + wtlen_p(GPat, 6) * wt_len(s, gp);
+              fec_len(gp) = elem_prod(wt_len(s, gp), fec_len(gp));
+              break;
             }
-            break;
-          }
-          case 5:
-          { // as eggs = a + b*Wt
-            fec_len(gp) = wtlen_p(GPat, 5) + wtlen_p(GPat, 6) * wt_len(s, gp);
-            if (wtlen_p(GPat, 5) < 0.0)
-            {
-              z = 1;
-              while (fec_len(gp, z) < 0.0)
-              {
-                fec_len(gp, z) = 0.0;
-                z++;
-              }
+            case 2:
+            { // as eggs = f(length)
+              fec_len(gp) = wtlen_p(GPat, 5) * pow(len_bins_m, wtlen_p(GPat, 6));
+              break;
             }
-            break;
+            case 3:
+            { // as eggs = f(body weight)
+              fec_len(gp) = wtlen_p(GPat, 5) * pow(wt_len(s, gp), wtlen_p(GPat, 6));
+              break;
+            }
+            case 4:
+            { // as eggs = a + b*Len
+              fec_len(gp) = wtlen_p(GPat, 5) + wtlen_p(GPat, 6) * len_bins_m;
+              if (wtlen_p(GPat, 5) < 0.0)
+              {
+                z = 1;
+                while (fec_len(gp, z) < 0.0)
+                {
+                  fec_len(gp, z) = 0.0;
+                  z++;
+                }
+              }
+              break;
+            }
+            case 5:
+            { // as eggs = a + b*Wt
+              fec_len(gp) = wtlen_p(GPat, 5) + wtlen_p(GPat, 6) * wt_len(s, gp);
+              if (wtlen_p(GPat, 5) < 0.0)
+              {
+                z = 1;
+                while (fec_len(gp, z) < 0.0)
+                {
+                  fec_len(gp, z) = 0.0;
+                  z++;
+                }
+              }
+              break;
+            }
           }
         }
         if (do_once == 1)
           echoinput << "maturity option: " << Maturity_Option << " parms: " << wtlen_p(GPat)(3, 4) << endl;
+
         switch (Maturity_Option)
         {
           case 1: //  Maturity_Option=1  length logistic

--- a/SS_param.tpl
+++ b/SS_param.tpl
@@ -92,7 +92,7 @@ PARAMETER_SECTION
   // If empirical wt-at-age is used, maturity and fecundity vectors are set to a distinctive value of 0.5
   // If parameters are used, then the calcs could be age-based or length-based or both, so start with default value of 1.0
   // These calculations happen in function get_mat_fec() in file SS_biofxn.tpl
-   if (WTage_rd == 1) {
+   if (WTage_rd == 1 || Maturity_Option == 4 || Maturity_Option == 5 ) {
      mat_len = 0.5;
      mat_age = 0.5;
      mat_fec_len = 0.5;

--- a/SS_param.tpl
+++ b/SS_param.tpl
@@ -88,11 +88,22 @@ PARAMETER_SECTION
   4darray Save_PopBio(styr-3*nseas,TimeMax_Fcast_std+nseas,1,2*pop,1,gmorph,0,nages)
 
  LOCAL_CALCS
-      // clang-format on
-      mat_len = 1.0;
-  mat_age = 1.0;
-  mat_fec_len = 1.0;
-  fec_len = 1.0;
+  // clang-format on
+  // If empirical wt-at-age is used, maturity and fecundity vectors are set to a distinctive value of 0.5
+  // If parameters are used, then the calcs could be age-based or length-based or both, so start with default value of 1.0
+  // These calculations happen in function get_mat_fec() in file SS_biofxn.tpl
+   if (WTage_rd == 1) {
+     mat_len = 0.5;
+     mat_age = 0.5;
+     mat_fec_len = 0.5;
+     fec_len = 0.5;
+   }
+   else {
+     mat_len = 1.0;
+     mat_age = 1.0;
+     mat_fec_len = 1.0;
+     fec_len = 1.0;
+   }    
   // clang-format off
  END_CALCS
 

--- a/SS_readcontrol_330.tpl
+++ b/SS_readcontrol_330.tpl
@@ -1066,12 +1066,14 @@
  END_CALCS
 
 !!//  SS_Label_Info_4.5.2 #Process biology
+  int do_fec_len                 //  switch based on maturity option to trigger fecundity calcs
   init_int Maturity_Option       // 1=length logistic; 2=age logistic; 3=read age-maturity
-                                  //  4=read age-fecundity;  6=read length-maturity
+                                  //  4=read age-fecundity;  5=read age-fec from wtatage.ss; 6=read length-maturity
+                            // options 1, 2, 3, 6 can be used with fecundity options to create fecundity-at-age: fec(g)
+                            // options 4 and 5 read fecundity directly, so the concept of maturity is not defined
  LOCAL_CALCS
       // clang-format on
-      echoinput
-      << Maturity_Option << "  Maturity_Option" << endl;
+      echoinput << Maturity_Option << "  Maturity_Option" << endl;
   if (Maturity_Option == 3 || Maturity_Option == 4)
   {
     k1 = N_GP;
@@ -1087,6 +1089,12 @@
   else
   {
     k2 = 0;
+  }
+  if (Maturity_Option == 5 || Maturity_Option == 4) {
+    do_fec_len = 0;
+  }
+  else {
+    do_fec_len = 1;
   }
   
   if (Maturity_Option == 5)

--- a/SS_readcontrol_330.tpl
+++ b/SS_readcontrol_330.tpl
@@ -1090,7 +1090,7 @@
   {
     k2 = 0;
   }
-  if (Maturity_Option == 5 || Maturity_Option == 4) {
+  if (Maturity_Option == 4 || Maturity_Option == 5) {
     do_fec_len = 0;
   }
   else {
@@ -1113,7 +1113,7 @@
  END_CALCS
   init_matrix Age_Maturity(1,k1,0,nages) // for maturity option 3 or 4
   init_matrix Length_Maturity(1,k2,1,nlength)  //  for maturity option 6
-!!if(k1>0) echoinput<<"  read Age_Maturity for each GP"<<Age_Maturity<<endl;
+!!if(k1>0) echoinput<<"  read Age_Maturity(3) or Age_Fecundity(4) for each GP"<<Age_Maturity<<endl;
 !!if(k2>0) echoinput<<"  read Length_Maturity for each GP"<<Length_Maturity<<endl;
 
   init_int First_Mature_Age     // first age with non-zero maturity

--- a/SS_write_report.tpl
+++ b/SS_write_report.tpl
@@ -3268,14 +3268,14 @@ FUNCTION void write_bigoutput()
     SS2out << sum(use_morph) << " " << nlength << " " << nages << " " << nseas << " N_Used_morphs;_lengths;_ages;_season;_by_season_in_endyr" << endl;
     if (gender == 2)
     {
-      SS2out << "GP Bin Low Mean_Size Wt_len_F Mat_len Spawn Wt_len_M Fecundity";
+      SS2out << "GP Bin Len_lo Len_mean Wt_F Mat Mat*Fec Wt_M Fec";
     }
     else
     {
-      SS2out << "GP Bin Low Mean_Size Wt_len Mat_len Spawn Fecundity";
+      SS2out << "GLen_lo Len_mean Wt_F Mat Mat*Fec Fec";
     }
     if(Maturity_Option == 4 || Maturity_Option == 5) {
-      SS2out << " // [Mat@Len, Spawn (Mat_Fec@Len), and Fecundity@Len reported as 0.5 because maturity option directly reads age_maturity]";
+      SS2out << " // [Mat, Mat*Fec, and Fec reported as 0.5 because maturity option directly reads age_fecundity]";
     }
     SS2out << endl;
     for (gp = 1; gp <= N_GP; gp++)

--- a/SS_write_report.tpl
+++ b/SS_write_report.tpl
@@ -3268,12 +3268,16 @@ FUNCTION void write_bigoutput()
     SS2out << sum(use_morph) << " " << nlength << " " << nages << " " << nseas << " N_Used_morphs;_lengths;_ages;_season;_by_season_in_endyr" << endl;
     if (gender == 2)
     {
-      SS2out << "GP Bin Low Mean_Size Wt_len_F Mat_len Spawn Wt_len_M Fecundity" << endl;
+      SS2out << "GP Bin Low Mean_Size Wt_len_F Mat_len Spawn Wt_len_M Fecundity";
     }
     else
     {
-      SS2out << "GP Bin Low Mean_Size Wt_len Mat_len Spawn Fecundity" << endl;
+      SS2out << "GP Bin Low Mean_Size Wt_len Mat_len Spawn Fecundity";
     }
+    if(Maturity_Option == 4 || Maturity_Option == 5) {
+      SS2out << " // [Mat@Len, Spawn (Mat_Fec@Len), and Fecundity@Len reported as 0.5 because maturity option directly reads age_maturity]";
+    }
+    SS2out << endl;
     for (gp = 1; gp <= N_GP; gp++)
       for (z = 1; z <= nlength; z++)
       {

--- a/SS_write_report.tpl
+++ b/SS_write_report.tpl
@@ -3272,7 +3272,7 @@ FUNCTION void write_bigoutput()
     }
     else
     {
-      SS2out << "GLen_lo Len_mean Wt_F Mat Mat*Fec Fec";
+      SS2out << "GP Bin Len_lo Len_mean Wt_F Mat Mat*Fec Fec";
     }
     if(Maturity_Option == 4 || Maturity_Option == 5) {
       SS2out << " // [Mat, Mat*Fec, and Fec reported as 0.5 because maturity option directly reads age_fecundity]";

--- a/SS_write_ssnew.tpl
+++ b/SS_write_ssnew.tpl
@@ -1780,8 +1780,10 @@ FUNCTION void write_nucontrol()
             << Length_Maturity << endl;
   }
   report4 << First_Mature_Age << " #_First_Mature_Age" << endl;
-
-  report4 << Fecund_Option << " #_fecundity option:(1)eggs=Wt*(a+b*Wt);(2)eggs=a*L^b;(3)eggs=a*Wt^b; (4)eggs=a+b*L; (5)eggs=a+b*W" << endl;
+  if (Maturity_Option == 4 || Maturity_Option == 5) {
+    report4 << "# NOTE: maturity options 4 and 5 cause fecundity_at_length to be ignored, but parameters still needed " << endl;
+  }
+  report4 << Fecund_Option << " #_fecundity_at_length option:(1)eggs=Wt*(a+b*Wt);(2)eggs=a*L^b;(3)eggs=a*Wt^b; (4)eggs=a+b*L; (5)eggs=a+b*W" << endl;
   report4 << Hermaphro_Option << " #_hermaphroditism option:  0=none; 1=female-to-male age-specific fxn; -1=male-to-female age-specific fxn" << endl;
   if (Hermaphro_Option != 0)
   {


### PR DESCRIPTION
## What issue(s) does this PR address? 
resolves #348 

## Describe the issue, if not included in the PR
some aspects of maturity and fecundity were being calculated even in not used; calculated values could be nonsensical if user provided placeholder rather than realistic parameter values.  Solution:  replace output  in these situations with a constant vector of 0.5.  Augment comments in code to describe the relevant situations.
## What tests have been done? Upload any model input files created for testing in a zip file, if possible.
minimal
## What tests/review still need to be done? Who can do it, and by when is it needed (ideally)?
try it out with the setup identified in issue #348 
## is there an input change for users to Stock Synthesis? 
no
If so, please provide an example of the new inputs needed.

```
[New example stock synthesis input goes here]

```

## Check which is true. This PR requires:

- [ ] no further changes to r4ss
- [x] no further changes to the manual
- [x] no further changes to SSI (the SS3 GUI)
- [x] no further changes to the stock synthesis change log (new features, bug reports)

## Describe any changes in r4ss/SS3 manual/SSI that are needed (if not checked):
r4ss needs to adjust headers for the biology_report (no. 42)

## If changes are needed in the change log, please fill in the table here:

Version | Date       | Description               | Issue        | Input change | Action                | Topic                                     | Type  |
| ----- | ---------- | ---------------------- | ------------ | ------------ | --------------------- | ----------------------------------------- | --------------------------------------- |
3.30.20 | [Add date] | [add concise description] | #[add issue] | [yes or no]  | [fix, new, or revise] | [e.g., biology. Use issue label options.] | [input, output, and/or calc, or ALL] |


## Additional information (optional):
