### PR TITLE
Change build trigger to be when a PR is opened

### DIFF
--- a/.github/workflows/ss3-pr-open-issues.yml
+++ b/.github/workflows/ss3-pr-open-issues.yml
@@ -1,14 +1,16 @@
 name: Open issues on merging PRs in r4ss, doc, and SSI repos
 on:
-  pull_request_target:
-    types:
-      - closed
+  pull_request:
+    types: [ready_for_review]
+#  pull_request_target:
+#    types:
+#      - closed
 jobs:
   ss3-pr-open-issues:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GH_PAT }}
-    if: github.event.pull_request.merged == true
+    #if: github.event.pull_request.merged == true
     steps:
       - uses: actions/checkout@v3
       - uses: r-lib/actions/setup-r@v2


### PR DESCRIPTION
## What issue(s) does this PR address? 
N/A

## Describe the issue, if not included in the PR
This addresses @iantaylor-NOAA 's suggestion to open dependent issues in current or other repositories when creating the pull request, rather than when merging it in. The exact build trigger used will open the issues when the pull request is opened as "ready for review", so draft pull requests will not create issues.

## What tests have been done? Upload any model input files created for testing in a zip file, if possible.

This build trigger has been used in the FIMS workflow https://github.com/NOAA-FIMS/FIMS/blob/main/.github/workflows/pr-checklist.yml , and seems to be working as expected.

## What tests/review still need to be done? Who can do it, and by when is it needed (ideally)?

Just need to know if others think that opening the issues on creation of the PR instead of merging is better or not.

## is there an input change for users to Stock Synthesis? 
No

If so, please provide an example of the new inputs needed.

```
[New example stock synthesis input goes here]

```

## Check which is true. This PR requires:

- [x] no further changes to r4ss
- [x] no further changes to the manual
- [x] no further changes to SSI (the SS3 GUI)
- [x] no further changes to the stock synthesis change log (new features, bug reports)

## Describe any changes in r4ss/SS3 manual/SSI that are needed (if not checked):

## If changes are needed in the change log, please fill in the table here:

Version | Date       | Description               | Issue        | Input change | Action                | Topic                                     | Type  |
| ----- | ---------- | ---------------------- | ------------ | ------------ | --------------------- | ----------------------------------------- | --------------------------------------- |
3.30.20 | [Add date] | [add concise description] | #[add issue] | [yes or no]  | [fix, new, or revise] | [e.g., biology. Use issue label options.] | [input, output, and/or calc, or ALL] |


## Additional information (optional):
