### PR TITLE
fix: bug in selex pattern 42, fixes #363

### DIFF
--- a/SS_selex.tpl
+++ b/SS_selex.tpl
@@ -667,19 +667,19 @@ FUNCTION void get_selectivity()
                   sp(1) = low_bin;
                   sp(2) = high_bin;
                   temp = mean(tempvec_l(low_bin, high_bin));
-                  scaling_offset = 0; // reset scaling offset
                 }
                 tempvec_l -= temp; // rescale to get max of 0.0
                 tempvec_l(j2 + 1, nlength) = tempvec_l(j2); //  set constant above last knot
                 sel = mfexp(tempvec_l);
-                // if spline code on first parameter line is 10, 11, or 12, then
+                // if spline code on third parameter line is 10, 11, or 12, then
                 // set to zero before the first knot (unless first knot is at first bin)
-                if ((sp(1) >= 10) & (j1 >= 1))
+                if ((sp(1 + scaling_offset) >= 10) & (j1 >= 1))
                 {
                   sel(1, j1) = 0; //  set to 0 before first knot
                 }
+                scaling_offset = 0; // reset scaling offset
                 break;
-              } // end cubic spline (type 42 or 27)
+              } // end length-based cubic spline (type 42 or 27)
               case 30:
               {
                 N_warn++;
@@ -1603,19 +1603,19 @@ FUNCTION void get_selectivity()
                   sp(1) = low_bin;
                   sp(2) = high_bin;
                   temp = mean(tempvec_a(low_bin, high_bin));
-                  scaling_offset = 0; // reset scaling offset
                 }
                 tempvec_a -= temp; // rescale to get max of 0.0
                 tempvec_a(j2 + 1, nages) = tempvec_a(j2); //  set constant above last knot
                 sel_a(y, fs, 1)(Min_selage(fs), nages) = mfexp(tempvec_a)(Min_selage(fs), nages);
-                // if spline code on first parameter line is 10, 11, or 12, then
+                // if spline code on third parameter line is 10, 11, or 12, then
                 // set to zero before the first knot (unless first knot is at age 0)
-                if ((sp(1) >= 10) & (j1 >= 0))
+                if ((sp(1 + scaling_offset) >= 10) & (j1 >= 0))
                 {
                   sel_a(y, fs, 1)(0, j1) = 0; //  set to 0 before first knot (unless first knot is at 0)
                 }
+                scaling_offset = 0; // reset scaling offset
                 break;
-              } // end case 27 cubic spline
+              } // end age-based cubic spline (type 42 or 27)
 
               default: //  seltype not found.  But really need this check earlier when the N selex parameters are being processed.
               {


### PR DESCRIPTION
## Concisely (20 words or less) describe the issue
Corrects bug associated with wrong parameter line references in selex pattern 42
## Please Link issue(s)

resolves #363 

## What tests have been done? Upload any model input files created for testing in a zip file, if possible.
Implemented in attached which runs fine without estimation. Estimation produces nan values but I think that's probably based on bad model design rather than problems with the code.
[BigSkate_splines_selex42_option10.zip](https://github.com/nmfs-stock-synthesis/stock-synthesis/files/9264173/BigSkate_splines_selex42_option10.zip)

## What tests/review still need to be done? Who can do it, and by when is it needed (ideally)?
Could be useful to add a proper example of selectivity pattern 42 for both length and age.

## Has any new code been documented?

If not, please add documentation before submitting the Pull Request.
- [ ] I have documented any new code added (or no new code was added)
I'm not totally clear on what this means.

## Check which is true. This PR requires:

- [x] no further changes to r4ss
- [ ] no further changes to the manual
- [x] no further changes to SSI (the SS3 GUI)
- [x] no further changes to the stock synthesis change log (new features, bug reports)

## Describe any changes in r4ss/SS3 manual/SSI that are needed (if not checked):
SS3 Manual should clarify that the 2 extra parameters required by pattern 42 come before all of the pattern 27 parameter lines, so the code parameter is now on the 3rd parameter line.

