### PR TITLE
fix extra value in M table (2nd try)

### DIFF
--- a/SS_write_report.tpl
+++ b/SS_write_report.tpl
@@ -3317,7 +3317,7 @@ FUNCTION void write_bigoutput()
               {
                 SS2out << " BENCH ";
               }
-              if (y == styr - 2)
+              else if (y == styr - 2)
               {
                 SS2out << " VIRG ";
               }


### PR DESCRIPTION
## Concisely (20 words or less) describe the issue
The recently-revised (in #307) Natural_Mortality table in Report.sso has an extra value in the output 
This PR replaces #367 which accidentally was based on the `MV-Tweedie-ver2` branch instead of `main`.

## Please Link issue(s)
No issue. Just a quick fix to a minor bug (example below).

## What tests have been done? Upload any model input files created for testing in a zip file, if possible.
Compiled SS3, ran a single model, confirm that the table looks correct.

## What tests/review still need to be done? Who can do it, and by when is it needed (ideally)?
Usual automated tests via GitHub action.

## Has any new code been documented?

If not, please add documentation before submitting the Pull Request.
- [x] I have documented any new code added (or no new code was added)

## Check which is true. This PR requires:

- [x] no further changes to r4ss
- [x] no further changes to the manual
- [x] no further changes to SSI (the SS3 GUI)
- [x] no further changes to the stock synthesis change log (new features, bug reports)

## Describe any changes in r4ss/SS3 manual/SSI that are needed (if not checked):

## Additional information (optional):
Example of the output with the extra "TIME" value in the "BENCH" rows:
```
Natural_Mortality report:43
Method: 0
Area Bio_Pattern Sex BirthSeas Settlement Platoon Morph Yr Seas Time Beg/Mid Era 0 1 2 ...
1 1 1 1 1 1 1 1968 1 1968 B BENCH  TIME  0.1 0.1 0.1 ...
1 1 1 1 1 1 1 1968 2 1968.96 B BENCH  TIME  0.1 0.1 0.1 ...
1 1 1 1 1 1 1 1969 1 1969 B VIRG  0.1 0.1 0.1 ...
1 1 1 1 1 1 1 1969 2 1969.96 B VIRG  0.1 0.1 0.1 ...
1 1 1 1 1 1 1 1970 1 1970 B INIT  0.1 0.1 0.1 ...
1 1 1 1 1 1 1 1970 2 1970.96 B INIT  0.1 0.1 0.1 ...
1 1 1 1 1 1 1 1971 1 1971 B TIME  0.1 0.1 0.1 ...
1 1 1 1 1 1 1 1971 2 1971.96 B TIME  0.1 0.1 0.1 ...
```