### PR TITLE
Fixes ADMB version number

### DIFF
--- a/SS_versioninfo_330opt.tpl
+++ b/SS_versioninfo_330opt.tpl
@@ -7,7 +7,7 @@ DATA_SECTION
 !! //  SS_Label_Info_1.1.1  #Create string with version info
 !!version_info += "#V3.30.xx.yy;_fast(opt);_compile_date:_";
 !!version_info += __DATE__;
-!!version_info += ";_Stock_Synthesis_by_Richard_Methot_(NOAA)_using_ADMB_12.3";
+!!version_info += ";_Stock_Synthesis_by_Richard_Methot_(NOAA)_using_ADMB_13.0";
 !!version_info2 += "#_Stock_Synthesis_is_a_work_of_the_U.S._Government_and_is_not_subject_to_copyright_protection_in_the_United_States.";
 !!version_info2 += "#_Foreign_copyrights_may_apply._See_copyright.txt_for_more_information.";
 !!version_info2 += "#_User_support_available_at:NMFS.Stock.Synthesis@noaa.gov";

--- a/SS_versioninfo_330safe.tpl
+++ b/SS_versioninfo_330safe.tpl
@@ -7,7 +7,7 @@ DATA_SECTION
 !! //  SS_Label_Info_1.1.1  #Create string with version info
 !!version_info += "#V3.30.xx.yy;_safe;_compile_date:_";
 !!version_info += __DATE__;
-!!version_info += ";_Stock_Synthesis_by_Richard_Methot_(NOAA)_using_ADMB_12.3";
+!!version_info += ";_Stock_Synthesis_by_Richard_Methot_(NOAA)_using_ADMB_13.0";
 !!version_info2 += "#_Stock_Synthesis_is_a_work_of_the_U.S._Government_and_is_not_subject_to_copyright_protection_in_the_United_States.";
 !!version_info2 += "#_Foreign_copyrights_may_apply._See_copyright.txt_for_more_information.";
 !!version_info2 += "#_User_support_available_at:NMFS.Stock.Synthesis@noaa.gov";


### PR DESCRIPTION
## Concisely (20 words or less) describe the issue
Updates the version number of ADMB to 13.0, using a hard-coded value.

## Please Link issue(s)
Resolves #373

If not, please add documentation before submitting the Pull Request.
- [x] I have documented any new code added (or no new code was added)

## is there an input change for users to Stock Synthesis? 

- [ ] Yes, there was an input change

If so, please provide an example of the new inputs needed.

```
[New example stock synthesis input goes here]

```

## Check which is true. This PR requires:

- [x] no further changes to r4ss
- [x] no further changes to the manual
- [x] no further changes to SSI (the SS3 GUI)
- [x] no further changes to the stock synthesis change log (new features, bug reports)

## Describe any changes in r4ss/SS3 manual/SSI that are needed (if not checked):

## If changes are needed in the change log, please fill in the table here:

| Action                | Topics                                     | Type  |
| --------------------- | ----------------------------------------- | --------------------------------------- |
| [fix, new, or revise] | [e.g., biology. Use issue label options.] | [input, output, and/or calc, or ALL] |


## Additional information (optional):
