### PR TITLE
378 bug nan in reportsso for sexratio in hermaphroditism model with second growth morph

### DIFF
--- a/SS_write_report.tpl
+++ b/SS_write_report.tpl
@@ -3574,7 +3574,10 @@ FUNCTION void write_bigoutput()
       SS2out << " Herma_Trans ";
     }
     if (gender == 2)
-      SS2out << " sex_ratio ";
+    {
+      for (p = 1; p <=pop; p++)
+        SS2out << " sex_ratio_area:_" << p ;
+    }
     for (f = 1; f <= Nfleet; f++)
       SS2out << " Len:_" << f << " SelWt:_" << f << " RetWt:_" << f;
     SS2out << endl;
@@ -3627,16 +3630,20 @@ FUNCTION void write_bigoutput()
                 SS2out << " NA ";
               }
             }
-            //  write sex ratio in endyr using natage in area 1
+            //  write sex ratio in endyr for each area using natage
+            //  small constant added to denominator so that morph-area combos with no fish will display a value of 0.0, rather than "nan"
+            //  because natage is used, the reported sex ratio values will be responsive to hermaphroditism, and to sex-specific mortality
             if (gender == 2)
             {
               if (sx(g) == 1)
               {
-                SS2out << " " << natage(t, 1, g, a) / (natage(t, 1, g, a) + natage(t, 1, g + gmorph / 2, a)) << " ";
+                for (p = 1; p <= pop; p++)
+                  SS2out << " " << natage(t, p, g, a) / (natage(t, p, g, a) + natage(t, p, g + gmorph / 2, a) + 1.0e-07) << " ";
               }
               else
               {
-                SS2out << " " << natage(t, 1, g, a) / (natage(t, 1, g, a) + natage(t, 1, g - gmorph / 2, a)) << " ";
+                for (p = 1; p <= pop; p++)
+                  SS2out << " " << natage(t, p, g, a) / (natage(t, p, g, a) + natage(t, p, g - gmorph / 2, a) + 1.0e-07) << " ";
               }
             }
             if (WTage_rd == 0)

--- a/StockSynthesis.code-workspace
+++ b/StockSynthesis.code-workspace
@@ -1,0 +1,12 @@
+{
+	"folders": [
+		{
+			"path": ".."
+		}
+	],
+	"settings": {
+		"files.associations": {
+			"\"*.extension\":": "\"tpl\""
+		}
+	}
+}


### PR DESCRIPTION
## Concisely (20 words or less) describe the issue
reporting of sex ratio in report.sso could produce nan because it was only using area 1 numbers
## Please Link issue(s)
#378 
resolves #[add issue number number], resolves #[optional second issue number if more than 1 issue addressed.]
#378 
## What tests have been done? Upload any model input files created for testing in a zip file, if possible.
visual examination of biology in endyr report table
## What tests/review still need to be done? Who can do it, and by when is it needed (ideally)?
none
## Has any new code been documented?
yes
If not, please add documentation before submitting the Pull Request.
- [ ] I have documented any new code added (or no new code was added)

## is there an input change for users to Stock Synthesis? 
no
- [ ] Yes, there was an input change

If so, please provide an example of the new inputs needed.

```
[New example stock synthesis input goes here]

```

## Check which is true. This PR requires:

- [x] no further changes to r4ss
- [ ] no further changes to the manual
- [X] no further changes to SSI (the SS3 GUI)
- [X] no further changes to the stock synthesis change log (new features, bug reports)

## Describe any changes in r4ss/SS3 manual/SSI that are needed (if not checked):
Inform users that output is now area_specific.  Column header format is now:  sex_ratio_area:X
## If changes are needed in the change log, please fill in the table here:

| Action                | Topics                                     | Type  |
| --------------------- | ----------------------------------------- | --------------------------------------- |
| [fix, new, or revise] | [e.g., biology. Use issue label options.] | [input, output, and/or calc, or ALL] |


## Additional information (optional):
