### PR TITLE
disable some reports with use of empirical wtatage

### DIFF
--- a/SS_readcontrol_330.tpl
+++ b/SS_readcontrol_330.tpl
@@ -66,12 +66,13 @@
   // clang-format on
   if (WTage_rd > 0)
   {
+    // Remove unnecessary or confusing reports (issue #383)
     pick_report_use(8) = "N";
     pick_report_use(27) = "N";
     pick_report_use(31) = "N";
     pick_report_use(38) = "N";
     pick_report_use(42) = "N";
-
+    // Incompatible option, fatal condition 
     if (nobs_mnwt > 0)
     {
       warnstream << "incompatible option:  empirical bodywt-at-age is used, but meanbody_wt obs fit using growth curve";

--- a/SS_readcontrol_330.tpl
+++ b/SS_readcontrol_330.tpl
@@ -75,7 +75,7 @@
     // Incompatible option, fatal condition 
     if (nobs_mnwt > 0)
     {
-	  warnstream << "expected value for mean body-wt will be from the growth curve, not from empirical wtatage.
+	  warnstream << "expected value for mean body-wt will be from the growth curve, not from empirical wtatage.ss";
       write_message (WARN, 1);
     }
   }

--- a/SS_readcontrol_330.tpl
+++ b/SS_readcontrol_330.tpl
@@ -75,8 +75,8 @@
     // Incompatible option, fatal condition 
     if (nobs_mnwt > 0)
     {
-      warnstream << "incompatible option:  empirical bodywt-at-age is used, but meanbody_wt obs fit using growth curve";
-      write_message (FATAL, 0);
+	  warnstream << "expected value for mean body-wt will be from the growth curve, not from empirical wtatage.
+      write_message (WARN, 1);
     }
   }
   

--- a/SS_readcontrol_330.tpl
+++ b/SS_readcontrol_330.tpl
@@ -64,10 +64,19 @@
   vector platoon_distr(1,N_platoon);
  LOCAL_CALCS
   // clang-format on
-  if (WTage_rd > 0 && nobs_mnwt > 0)
+  if (WTage_rd > 0)
   {
-    warnstream << "incompatible option:  empirical bodywt-at-age is used, but meanbody_wt obs fit using growth curve";
-    write_message (ADJUST, 0);
+    pick_report_use(8) = "N";
+    pick_report_use(27) = "N";
+    pick_report_use(31) = "N";
+    pick_report_use(38) = "N";
+    pick_report_use(42) = "N";
+
+    if (nobs_mnwt > 0)
+    {
+      warnstream << "incompatible option:  empirical bodywt-at-age is used, but meanbody_wt obs fit using growth curve";
+      write_message (FATAL, 0);
+    }
   }
   
   if (N_platoon > 1)


### PR DESCRIPTION
Deleted reports 8, 27, 31, 38, and 42 when reading wtatage.ss.  The message about nobs_mnwt is changed to FATAL (unrelated fix)

## Concisely (20 words or less) describe the issue
Deleting reports that give confusing or unnecessary info when using empirical wt-at-age.

## Please Link issue(s)

resolves #383.

## What tests have been done? Upload any model input files created for testing in a zip file, if possible.
used Hake_2018 from test_models.

## What tests/review still need to be done? Who can do it, and by when is it needed (ideally)?

## Has any new code been documented?

If not, please add documentation before submitting the Pull Request.
- [x] I have documented any new code added (or no new code was added)

## is there an input change for users to Stock Synthesis? 

- [ ] Yes, there was an input change

If so, please provide an example of the new inputs needed.

```
[New example stock synthesis input goes here]

```

## Check which is true. This PR requires:

- [ ] no further changes to r4ss
- [ ] no further changes to the manual
- [x] no further changes to SSI (the SS3 GUI)
- [ ] no further changes to the stock synthesis change log (new features, bug reports)

## Describe any changes in r4ss/SS3 manual/SSI that are needed (if not checked):

## If changes are needed in the change log, please fill in the table here:

| Action                | Topics                                     | Type  |
| --------------------- | ----------------------------------------- | --------------------------------------- |
| [fix, new, or revise] | [e.g., biology. Use issue label options.] | [input, output, and/or calc, or ALL] |


## Additional information (optional):
