### PR TITLE
Update broken links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Download the latest compiled versions from [Github Releases](https://github.com/
 
 To learn more about how to use Stock Synthesis, see the [getting started guide with Stock Synthesis guide](https://nmfs-stock-synthesis.github.io/doc/Getting_Started_SS.html). To learn how to build your own models in Stock Synthesis, see the [Develop an Stock Synthesis model guide](https://nmfs-stock-synthesis.github.io/doc/ss_model_tips.html).
 
-The [Stock Synthesis user manual](https://github.com/nmfs-stock-synthesis/doc/releases) provides the complete documentation of Stock Synthesis, while the [helper spreadsheets](https://github.com/nmfs-stock-synthesis/doc/tree/main/excel_output_viewer) are useful cheatsheets that outline inputs necessary for options that are widely used within Stock Synthesis.
+The [Stock Synthesis user manual](https://github.com/nmfs-stock-synthesis/doc/releases) provides the complete documentation of Stock Synthesis, while the [SS3 Shiny helper app](https://connect.fisheries.noaa.gov/ss3-helper/) can help users visualize common selectivity pattern options available within Stock Synthesis.
 
 ## How do I ask questions about Stock Synthesis?
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Download the latest compiled versions from [Github Releases](https://github.com/
 
 ## How can I learn how to use Stock Synthesis?
 
-To learn more about how to use Stock Synthesis, see the [getting started guide with Stock Synthesis guide](https://nmfs-stock-synthesis.github.io/ss-documentation/Getting_Started_SS.html). To learn how to build your own models in Stock Synthesis, see the [Develop an Stock Synthesis model guide](https://nmfs-stock-synthesis.github.io/ss-documentation/ss_model_tips.html).
+To learn more about how to use Stock Synthesis, see the [getting started guide with Stock Synthesis guide](https://nmfs-stock-synthesis.github.io/doc/Getting_Started_SS.html). To learn how to build your own models in Stock Synthesis, see the [Develop an Stock Synthesis model guide](https://nmfs-stock-synthesis.github.io/doc/ss_model_tips.html).
 
-The [Stock Synthesis user manual](https://github.com/nmfs-stock-synthesis/ss-documentation/releases) provides the complete documentation of Stock Synthesis, while the [helper spreadsheets](https://github.com/nmfs-stock-synthesis/ss-documentation/tree/main/Helper_Spreadsheets) are useful cheatsheets that outline inputs necessary for options that are widely used within Stock Synthesis.
+The [Stock Synthesis user manual](https://github.com/nmfs-stock-synthesis/doc/releases) provides the complete documentation of Stock Synthesis, while the [helper spreadsheets](https://github.com/nmfs-stock-synthesis/doc/tree/main/excel_output_viewer) are useful cheatsheets that outline inputs necessary for options that are widely used within Stock Synthesis.
 
 ## How do I ask questions about Stock Synthesis?
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Download the latest compiled versions from [Github Releases](https://github.com/
 
 To learn more about how to use Stock Synthesis, see the [getting started guide with Stock Synthesis guide](https://nmfs-stock-synthesis.github.io/doc/Getting_Started_SS.html). To learn how to build your own models in Stock Synthesis, see the [Develop an Stock Synthesis model guide](https://nmfs-stock-synthesis.github.io/doc/ss_model_tips.html).
 
-The [Stock Synthesis user manual](https://github.com/nmfs-stock-synthesis/doc/releases) provides the complete documentation of Stock Synthesis, while the [SS3 Shiny helper app](https://connect.fisheries.noaa.gov/ss3-helper/) can help users visualize common selectivity pattern options available within Stock Synthesis.
+The [Stock Synthesis user manual](https://nmfs-stock-synthesis.github.io/doc/SS330_User_Manual.html) provides the complete documentation of Stock Synthesis.
 
 ## How do I ask questions about Stock Synthesis?
 
@@ -50,6 +50,7 @@ As Stock Synthesis usage has grown, so has the number of tools to work with it. 
 - [ss3diags](https://github.com/PIFSCstockassessments/ss3diags): Run advanced diagnostics for Stock Synthesis models.
 - [ss3sim](https://github.com/ss3sim/ss3sim): Conduct simulation studies using Stock Synthesis.
 - [SSI](https://vlab.noaa.gov/web/stock-synthesis/document-library/-/document_library/0LmuycloZeIt/view/5042951): Stock Synthesis Interface, a GUI for developing models and running Stock Synthesis. Links to r4ss.
+- [SS3 Shiny helper app](https://connect.fisheries.noaa.gov/ss3-helper/): Visualize common selectivity pattern options available within Stock Synthesis.
 - [SSMSE](https://github.com/nmfs-fish-tools/SSMSE): Use Stock Synthesis operating models in Management Strategy Evaluation.
 - [sa4ss](https://github.com/nwfsc-assess/sa4ss): Create accessible R markdown stock assessment documents with results from Stock Synthesis models. Note this tool is intended for use by analysts within the Northwest and Southwest Fisheries Science Centers currently.
 - Data limited tools - Options included Simple Stock Synthesis ([SSS](https://github.com/shcaba/SSS)) and Extended Simple Stock Synthesis ([XSSS](https://github.com/chantelwetzel-noaa/XSSS)), as well as [SS-DL-tool](https://github.com/shcaba/SS-DL-tool), a shiny app that includes XSSS and SSS in its functionality.


### PR DESCRIPTION
Updated broken links - these links look like they used to be in a repository called "ss-documentation" which is now called "doc" and the links have been updated accordingly.

## Concisely (20 words or less) describe the issue

## Please Link issue(s)

resolves #385

## What tests have been done? Upload any model input files created for testing in a zip file, if possible.
None, updating the readme links
## What tests/review still need to be done? Who can do it, and by when is it needed (ideally)?
Double check that links now work.
## Has any new code been documented?
No need.

## Check which is true. This PR requires:

- [x] no further changes to r4ss
- [x] no further changes to the manual
- [x] no further changes to SSI (the SS3 GUI)
- [x] no further changes to the stock synthesis change log (new features, bug reports)

## Describe any changes in r4ss/SS3 manual/SSI that are needed (if not checked):

## If changes are needed in the change log, please fill in the table here:

| Action                | Topics                                     | Type  |
| --------------------- | ----------------------------------------- | --------------------------------------- |
| [fix, new, or revise] | [e.g., biology. Use issue label options.] | [input, output, and/or calc, or ALL] |


## Additional information (optional):
