### PR TITLE
fix array bound error in MCEVAL #397

### DIFF
--- a/SS_global.tpl
+++ b/SS_global.tpl
@@ -992,7 +992,6 @@ FINAL_SECTION
     //  SS_Label_Info_12.3.2 #Set save_for_report=1 then call initial_conditions and time_series to get other output quantities
     if (Do_Dyn_Bzero > 0) //  do dynamic Bzero
     {
-      save_gparm = 0;
       fishery_on_off = 0;
       setup_recdevs();
       y = styr;
@@ -1022,7 +1021,6 @@ FINAL_SECTION
     fishery_on_off = 1;
     save_for_report = 1;
     bigsaver = 1;
-    save_gparm = 0;
     if (SDmode == 0 && pick_report_use(60) == "Y")
       write_bodywt = 1; //  turn on conditional on SDMode because SDMode=1 situation already written
     y = styr;
@@ -1329,7 +1327,6 @@ REPORT_SECTION
       write_bodywt = 1;
     }
     save_for_report = 1;
-    save_gparm = 0;
     y = styr;
     setup_recdevs();
     get_initial_conditions();

--- a/SS_popdyn.tpl
+++ b/SS_popdyn.tpl
@@ -86,6 +86,7 @@ FUNCTION void get_initial_conditions()
   annual_catch.initialize();
   annual_F.initialize();
   Recr.initialize();
+  save_gparm = 0;  //  index for saving time-varying changes to biology quantities
 
   if (SzFreq_Nmeth > 0)
     SzFreq_exp.initialize();

--- a/SS_proced.tpl
+++ b/SS_proced.tpl
@@ -21,7 +21,6 @@ PROCEDURE_SECTION
 
   if (initial_params::mc_phase == 1) //  in MCMC phase
   {
-
     if (mcmc_counter == 0)
     {
       SR_parm(1) += MCMC_bump;
@@ -105,7 +104,6 @@ PROCEDURE_SECTION
 
       if (Do_Dyn_Bzero > 0) //  do dynamic Bzero
       {
-        save_gparm = 0;
         fishery_on_off = 0;
         setup_recdevs();
         y = styr;
@@ -132,7 +130,6 @@ PROCEDURE_SECTION
         }
       } //  end dynamic Bzero calculations, will write after big report
 
-      save_gparm = 0;
       fishery_on_off = 1;
       if (mceval_phase() > 0)
         save_for_report = 1;

--- a/SS_readdata_330.tpl
+++ b/SS_readdata_330.tpl
@@ -4093,6 +4093,14 @@
     {
       echoinput << " #mean recruitment and recrdist from years: " << Fcast_Rec_yr1 << " to " << Fcast_Rec_yr2 << endl;
     }
+    else if (Fcast_Loop_Control(3) == 4)
+    {
+      echoinput << " #mean recruitment from years: " << Fcast_Rec_yr1 << " to " << Fcast_Rec_yr2 << " recrdist from parameters" << endl;
+    }
+    else if (Fcast_Loop_Control(3) == 5)
+    {
+      echoinput << " #mean recrdist from years: " << Fcast_Rec_yr1 << " to " << Fcast_Rec_yr2 << " recruitment is from spawn_recr " << endl;
+    }
     else //  input probably was a -1 from pre 3.30.15, so convert to 0
     {
       Fcast_Loop_Control(3) = 0;

--- a/SS_readstarter.tpl
+++ b/SS_readstarter.tpl
@@ -87,7 +87,6 @@
   int save_gparm_print;
 !! save_for_report = 0;
 !! bigsaver = 0;
-!! save_gparm = 0;
 !! write_bodywt = 0;
 !! write_bodywt_save = 0;
 !! special_flag = 0;

--- a/SS_recruit.tpl
+++ b/SS_recruit.tpl
@@ -211,6 +211,10 @@ FUNCTION void apply_recdev(prevariable& NewRecruits, const prevariable& Recr_vir
   {
     switch (int(Fcast_Loop_Control(3)))
     {
+      case 5:
+      {
+        //  fall through to case 0
+      }
       case 0:
       {
         NewRecruits = exp_rec(y, 2);

--- a/SS_write.tpl
+++ b/SS_write.tpl
@@ -1155,7 +1155,6 @@ FUNCTION void write_Bzero_output()
       }
     SS2out << endl;
 
-    save_gparm = 0;
     if (fishery_on_off == 0)
     {
       setup_recdevs();


### PR DESCRIPTION
move reset of save_gparm such that mceval does not overflow array bound

## Concisely (20 words or less) describe the issue
resolves issue #397 
## Please Link issue(s)

resolves #397 

## What tests have been done? Upload any model input files created for testing in a zip file, if possible.
ran example provided by @puntae
## What tests/review still need to be done? Who can do it, and by when is it needed (ideally)?
none
## Has any new code been documented?
yes
If not, please add documentation before submitting the Pull Request.
- [X] I have documented any new code added (or no new code was added)

## is there an input change for users to Stock Synthesis? 

- [ ] Yes, there was an input change

If so, please provide an example of the new inputs needed.

```
[New example stock synthesis input goes here]

```

## Check which is true. This PR requires:

- [X] no further changes to r4ss
- [X] no further changes to the manual
- [X] no further changes to SSI (the SS3 GUI)
- [X] no further changes to the stock synthesis change log (new features, bug reports)

## Describe any changes in r4ss/SS3 manual/SSI that are needed (if not checked):

## If changes are needed in the change log, please fill in the table here:

| Action                | Topics                                     | Type  |
| --------------------- | ----------------------------------------- | --------------------------------------- |
| [fix, new, or revise] | [e.g., biology. Use issue label options.] | [input, output, and/or calc, or ALL] |


## Additional information (optional):
