### PR TITLE
depletion rel dyn_Bzero - working

### DIFF
--- a/SS_objfunc.tpl
+++ b/SS_objfunc.tpl
@@ -1201,6 +1201,17 @@ FUNCTION void Process_STDquant()
       depletion /= (depletion_level * SSB_yr(endyr));
       break;
     }
+    case 5:  //  dynamic Bzero
+    {
+      for (y = first_catch_yr; y <= YrMax; y++)
+      if (STD_Yr_Reverse_Dep(y) > 0)
+      {
+//        warning<<y<<" "<<STD_Yr_Reverse_Dep(y) <<" Ind "<<Do_Dyn_Bzero<<" "<< Do_Dyn_Bzero+ y - (styr - 2)<<" num: "<<depletion(STD_Yr_Reverse_Dep(y))<<" denom: "<<Extra_Std(Do_Dyn_Bzero + y - (styr -2))<<" depl ";
+        depletion(STD_Yr_Reverse_Dep(y)) /= ( depletion_level * Extra_Std(Do_Dyn_Bzero + y - (styr - 2)));
+//        warning<<depletion(STD_Yr_Reverse_Dep(y))<<endl;
+      }
+      break;
+    }
   }
   if (depletion_log == 1)
     depletion = log(depletion);

--- a/SS_readcontrol_330.tpl
+++ b/SS_readcontrol_330.tpl
@@ -6698,6 +6698,11 @@
       depletion_basis_label += " " + onenum + "%*EndYr_Biomass";
       break;
     }
+    case 5:
+    {
+      depletion_basis_label += " " + onenum + "%*Dyn_Bzero";
+      break;
+    }
   }
   if (depletion_log == 1) depletion_basis_label += ";log";
   if (depletion_multi > 1)

--- a/SS_readdata_330.tpl
+++ b/SS_readdata_330.tpl
@@ -4753,10 +4753,10 @@
 
 
 !!// SS_Label_Info_3.2 #Create complete list of years for STD reporting
-  ivector STD_Yr_Reverse(styr-2,YrMax);
-  ivector STD_Yr_Reverse_Dep(styr-2,YrMax);
-  ivector STD_Yr_Reverse_Ofish(styr-2,YrMax);
-  ivector STD_Yr_Reverse_F(styr-2,YrMax);
+  ivector STD_Yr_Reverse(styr-2,YrMax);   //  contains 0/1 for each year to indicate std reporting
+  ivector STD_Yr_Reverse_Dep(styr-2,YrMax);  //  contains index number to i'th depletion (e.g. Bratio) std
+  ivector STD_Yr_Reverse_Ofish(styr-2,YrMax);  //  ditto
+  ivector STD_Yr_Reverse_F(styr-2,YrMax);  //  ditto
   int N_STD_Yr_Dep;
   int N_STD_Yr_Ofish;
   int N_STD_Yr_F;
@@ -4782,18 +4782,13 @@
   STD_Yr_Reverse(styr) = 1;
   for (i = 1; i <= N_STD_Yr_RD; i++)
   {
-    if (STD_Yr_RD(i) >= styr && STD_Yr_RD(i) < YrMax)
+    if (STD_Yr_RD(i) >= styr && STD_Yr_RD(i) <= YrMax)
     {
       STD_Yr_Reverse(STD_Yr_RD(i)) = 1;
     }
   }
+  N_STD_Yr = sum(STD_Yr_Reverse);  //  count number of years for which std is requested
 
-  N_STD_Yr = sum(STD_Yr_Reverse);
-  // clang-format off
- END_CALCS
-
- LOCAL_CALCS
-  // clang-format on
   STD_Yr_Reverse_Dep.initialize();
   STD_Yr_Reverse_Ofish.initialize();
   STD_Yr_Reverse_F.initialize();

--- a/SS_readstarter.tpl
+++ b/SS_readstarter.tpl
@@ -634,7 +634,7 @@
   int depletion_basis;
   int depletion_multi;
   int depletion_log;
-  init_int depletion_basis_rd; // 0=skip; 1=fraction of B0; 2=fraction of Bmsy where fraction is depletion_level 3=rel to styr; values >=11 invoke multiyr with 10's digit; >=100 invoke log(ratio) with hundreds digit
+  init_int depletion_basis_rd; // 0=skip; 1=B0; 2=Bmsy; 3=B_styr; 4=B_endyr; 5=dynamic_Bzero; values >=11 invoke multiyr with 10's digit; >=100 invoke log(ratio) with hundreds digit
  LOCAL_CALCS
   // clang-format on
   echoinput << depletion_basis_rd << "  depletion_basis as read; this is also known as Bratio and is a std quantity; has multi-yr and log(ratio) options" << endl;
@@ -730,7 +730,7 @@
       warnstream << "new feature for multiyr F_std reporting, be sure STD reporting covers all years from styr to endyr";
       write_message(NOTE, 0);
     }
-    echoinput << "For Kobe plot, set depletion_basis=2; depletion_level=1.0; F_reporting=your choose; F_std_basis=2" << endl;
+    echoinput << "For Kobe plot, set depletion_basis=2; depletion_level=1.0; F_reporting=your choice; F_std_basis=2" << endl;
 
     mcmc_output_detail = 0;
     MCMC_bump = 0.;

--- a/SS_write_ssnew.tpl
+++ b/SS_write_ssnew.tpl
@@ -1451,7 +1451,7 @@ FUNCTION void write_nucontrol()
   NuStart << final_conv << " # final convergence criteria (e.g. 1.0e-04) " << endl;
   NuStart << retro_yr - endyr << " # retrospective year relative to end year (e.g. -4)" << endl;
   NuStart << Smry_Age << " # min age for calc of summary biomass" << endl;
-  NuStart << depletion_basis_rd << " # Depletion basis:  denom is: 0=skip; 1=rel X*SPBvirgin; 2=rel SPBmsy; 3=rel X*SPB_styr; 4=rel X*SPB_endyr; values; >=11 invoke N multiyr (up to 9!) with 10's digit; >100 invokes log(ratio)" << endl;
+  NuStart << depletion_basis_rd << " # Depletion basis:  denom is: 0=skip; 1=X*SPBvirgin; 2=X*SPBmsy; 3=X*SPB_styr; 4=X*SPB_endyr; 5=X*dyn_Bzero;  values>=11 invoke N multiyr (up to 9!) with 10's digit; >100 invokes log(ratio)" << endl;
   NuStart << depletion_level << " # Fraction (X) for Depletion denominator (e.g. 0.4)" << endl;
   NuStart << SPR_reporting << " # SPR_report_basis:  0=skip; 1=(1-SPR)/(1-SPR_tgt); 2=(1-SPR)/(1-SPR_MSY); 3=(1-SPR)/(1-SPR_Btarget); 4=rawSPR" << endl;
   NuStart << F_reporting << " # F_reporting_units: 0=skip; 1=exploitation(Bio); 2=exploitation(Num); 3=sum(Apical_F's); 4=true F for range of ages; 5=unweighted avg. F for range of ages" << endl;


### PR DESCRIPTION
successfully add depletion option 5 to use dynamic Bzero as denominator

## Concisely (20 words or less) describe the issue
per request from @SteveTeo-noaa add depletion option 5 that uses dynamic Bzero as the denominator
resolves #69 

## What tests have been done? Upload any model input files created for testing in a zip file, if possible.
created example using simple.  example output attached
[Dyn_Bzero.zip](https://github.com/nmfs-stock-synthesis/stock-synthesis/files/10416386/Dyn_Bzero.zip)

## What tests/review still need to be done? Who can do it, and by when is it needed (ideally)?
standard
## Has any new code been documented?
yes
If not, please add documentation before submitting the Pull Request.
- [X] I have documented any new code added (or no new code was added)

## is there an input change for users to Stock Synthesis? 

- [X] Yes, there was an input change

If so, please provide an example of the new inputs needed.
new option is 5
5 # Depletion basis:  denom is: 0=skip; 1=X*SPBvirgin; 2=X*SPBmsy; 3=X*SPB_styr; 4=X*SPB_endyr; 5=X*dyn_Bzero;  values>=11 invoke N multiyr (up to 9!) with 10's digit; >100 invokes log(ratio)
## Check which is true. This PR requires:

- [x] no further changes to r4ss
- [ ] no further changes to the manual
- [ ] no further changes to SSI (the SS3 GUI)
- [x] no further changes to the stock synthesis change log (new features, bug reports)

## Describe any changes in r4ss/SS3 manual/SSI that are needed (if not checked):
ask me when ready
## If changes are needed in the change log, please fill in the table here:

## Additional information (optional):
@jimianelli