### PR TITLE
add dyn_Bzero warning

### DIFF
--- a/SS_readcontrol_330.tpl
+++ b/SS_readcontrol_330.tpl
@@ -6618,6 +6618,11 @@
       ParmLabel += "Dyn_Bzero_" + onenum + CRLF(1);
     }
   }
+  else if (depletion_basis_rd == 5)
+  {
+    warnstream << "must select dyn_bzero in control file extra_std for it to be used as depletion denominator ";
+    write_message (FATAL, 0); // EXIT!
+  }
   if (More_Std_Input(12) == 2)
   {
     echoinput << " do Dyn Bzero Recruits std labels " << endl;


### PR DESCRIPTION
add warning so dyn_Bzero cannot be selected as depletion denominator unless first selected in extra_std

## Please Link issue(s)
#69 
resolves #[add issue number number], resolves #[optional second issue number if more than 1 issue addressed.]
#69
## What tests have been done? Upload any model input files created for testing in a zip file, if possible.
warning appears if erroneous setup is used
## What tests/review still need to be done? Who can do it, and by when is it needed (ideally)?
none
## Has any new code been documented?
of course
If not, please add documentation before submitting the Pull Request.
- [X] I have documented any new code added (or no new code was added)

## is there an input change for users to Stock Synthesis? 
no

If so, please provide an example of the new inputs needed.

```
[New example stock synthesis input goes here]

```

## Check which is true. This PR requires:

- [X] no further changes to r4ss
- [X] no further changes to the manual
- [X] no further changes to SSI (the SS3 GUI)
- [X] no further changes to the stock synthesis change log (new features, bug reports)

## Describe any changes in r4ss/SS3 manual/SSI that are needed (if not checked):

## If changes are needed in the change log, please fill in the table here:

| Action                | Topics                                     | Type  |
| --------------------- | ----------------------------------------- | --------------------------------------- |
| [fix, new, or revise] | [e.g., biology. Use issue label options.] | [input, output, and/or calc, or ALL] |


## Additional information (optional):
