### PR TITLE
WIP; correct spawn_recr output; still working Hess

### DIFF
--- a/SS_benchfore.tpl
+++ b/SS_benchfore.tpl
@@ -2455,7 +2455,7 @@ FUNCTION void Get_Forecast()
             }
 
             Recruits = Spawn_Recr(SSB_use, R0_use, SSB_current); // calls to function Spawn_Recr
-            apply_recdev(Recruits, R0_use); //  apply recruitment deviation
+            if (SR_fxn != 7) apply_recdev(Recruits, R0_use); //  apply recruitment deviation
             if (Fcast_Loop1 < Fcast_Loop_Control(2)) //  use expected recruitment  this should include environ effect - CHECK THIS
             {
               Recruits = exp_rec(y, 2);
@@ -3082,7 +3082,7 @@ FUNCTION void Get_Forecast()
             }
 
             Recruits = Spawn_Recr(SSB_use, R0_use, SSB_current); // calls to function Spawn_Recr
-            apply_recdev(Recruits, R0_use); //  apply recruitment deviation
+            if (SR_fxn != 7) apply_recdev(Recruits, R0_use); //  apply recruitment deviation
             // distribute Recruitment  among the settlements, areas and morphs
             for (g = 1; g <= gmorph; g++)
               if (use_morph(g) > 0)

--- a/SS_popdyn.tpl
+++ b/SS_popdyn.tpl
@@ -1019,7 +1019,7 @@ FUNCTION void get_time_series()
           SSB_use = SSB_equil;
         }
         Recruits = Spawn_Recr(SSB_use, R0_use, SSB_current); // calls to function Spawn_Recr
-        apply_recdev(Recruits, R0_use); //  apply recruitment deviation
+        if (SR_fxn != 7) apply_recdev(Recruits, R0_use); //  apply recruitment deviation
         // distribute Recruitment of age 0 fish among the current and future settlements; and among areas and morphs
         //  use t offset for each birth event:  Settlement_offset(settle)
         //  so the total number of Recruits will be relative to their numbers at the time of the set of settlement_events.
@@ -1461,7 +1461,7 @@ FUNCTION void get_time_series()
         }
 
         Recruits = Spawn_Recr(SSB_use, R0_use, SSB_current); // calls to function Spawn_Recr
-        apply_recdev(Recruits, R0_use); //  apply recruitment deviation
+        if (SR_fxn != 7) apply_recdev(Recruits, R0_use); //  apply recruitment deviation
 
         // distribute Recruitment among settlements, areas and morphs
         //  note that because SSB_current is calculated at end of season to take into account Z,

--- a/SS_recruit.tpl
+++ b/SS_recruit.tpl
@@ -344,6 +344,7 @@ FUNCTION dvar_vector Equil_Spawn_Recr_Fxn(const prevariable& SRparm2, const prev
       SRZ_0 = log(1.0 / (SSB_virgin / Recr_virgin));
       srz_min = SRZ_0 * (1.0 - steepness);
       B_equil = SSB_virgin * (1. - (log(1. / SPR_temp) - SRZ_0) / pow((srz_min - SRZ_0), (1. / 1.)));
+      B_equil = posfun(B_equil, 0.0001, temp);
       SRZ_surv = mfexp((1. - pow((B_equil / SSB_virgin), 1.)) * (srz_min - SRZ_0) + SRZ_0); //  survival
 //      B_equil = SSB_virgin * (1. - (log(1. / SPR_temp) - SRZ_0) / pow((srz_min - SRZ_0), (1. / SRparm3)));
 //      SRZ_surv = mfexp((1. - pow((B_equil / SSB_virgin), SRparm3)) * (srz_min - SRZ_0) + SRZ_0); //  survival

--- a/SS_recruit.tpl
+++ b/SS_recruit.tpl
@@ -123,6 +123,7 @@ FUNCTION dvariable Spawn_Recr(const prevariable& SSB_virgin_adj, const prevariab
         SRZ_surv *= mfexp(recdev_cycle_parm(gg));
       }
       exp_rec(y, 2) = SSB_curr_adj * SRZ_surv;
+      exp_rec(y, 2) *= mfexp(regime_change); //  adjust for regime which includes env and block effects; and forecast adjustments
       SRZ_surv *= mfexp(-biasadj(y) * half_sigmaRsq); // bias adjustment
       exp_rec(y, 3) = SSB_curr_adj * SRZ_surv;
       if (y <= recdev_end)
@@ -342,8 +343,10 @@ FUNCTION dvar_vector Equil_Spawn_Recr_Fxn(const prevariable& SRparm2, const prev
     {
       SRZ_0 = log(1.0 / (SSB_virgin / Recr_virgin));
       srz_min = SRZ_0 * (1.0 - steepness);
-      B_equil = SSB_virgin * (1. - (log(1. / SPR_temp) - SRZ_0) / pow((srz_min - SRZ_0), (1. / SRparm3)));
-      SRZ_surv = mfexp((1. - pow((B_equil / SSB_virgin), SRparm3)) * (srz_min - SRZ_0) + SRZ_0); //  survival
+      B_equil = SSB_virgin * (1. - (log(1. / SPR_temp) - SRZ_0) / pow((srz_min - SRZ_0), (1. / 1.)));
+      SRZ_surv = mfexp((1. - pow((B_equil / SSB_virgin), 1.)) * (srz_min - SRZ_0) + SRZ_0); //  survival
+//      B_equil = SSB_virgin * (1. - (log(1. / SPR_temp) - SRZ_0) / pow((srz_min - SRZ_0), (1. / SRparm3)));
+//      SRZ_surv = mfexp((1. - pow((B_equil / SSB_virgin), SRparm3)) * (srz_min - SRZ_0) + SRZ_0); //  survival
       R_equil = B_equil * SRZ_surv;
       break;
     }


### PR DESCRIPTION
## Concisely (20 words or less) describe the issue
see dialogue with the issue.  The solution was to make SRR_7 robust with a posfun(), just as is done for other SRR
## Please Link issue(s)
#420 
resolves #[add issue number number], resolves #[optional second issue number if more than 1 issue addressed.]
#420
## What tests have been done? Upload any model input files created for testing in a zip file, if possible.
WIP
## What tests/review still need to be done? Who can do it, and by when is it needed (ideally)?
fixed output table;
Hessian still notdef so hard-wired beta to value of 0.0 in equil section
## Has any new code been documented?

If not, please add documentation before submitting the Pull Request.
- [X] I have documented any new code added (or no new code was added)

## is there an input change for users to Stock Synthesis? 

- [ ] Yes, there was an input change

If so, please provide an example of the new inputs needed.

```
[New example stock synthesis input goes here]

```

## Check which is true. This PR requires:

- [ ] no further changes to r4ss
- [ ] no further changes to the manual
- [ ] no further changes to SSI (the SS3 GUI)
- [ ] no further changes to the stock synthesis change log (new features, bug reports)

## Describe any changes in r4ss/SS3 manual/SSI that are needed (if not checked):

## If changes are needed in the change log, please fill in the table here:

| Action                | Topics                                     | Type  |
| --------------------- | ----------------------------------------- | --------------------------------------- |
| [fix, new, or revise] | [e.g., biology. Use issue label options.] | [input, output, and/or calc, or ALL] |


## Additional information (optional):
