### PR TITLE
Create new_issue_template.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/new_issue_template.yml
@@ -18,8 +18,18 @@ body:
 - type: textarea
   id: summary
   attributes:
-    label: Summary of Issue History and Discussion 
-    description: A summary of pertinent information on this issue that occurred in the discussion or via email. The person creating the issue is responsible for adding info from the discussion to this section.
+    label: Summary of Issue History, Discussion, and Major Aspects of Code Development 
+    description: A summary of pertinent information on this issue, including major aspects of code development, that occurred in the discussion/via email. The person creating the issue is responsible for adding info from the discussion to this section.
+    placeholder: |
+      - This issue is realted to issue #X.
+      - Will need to create an example vignette for this feature.
+      - example input change
+        ```
+        #_MG_type method st_year end_year 
+        1 1 2002 2003 # (M) NatMort 
+        4 1 2016 2018 # RecrDist 
+        -9999 -1 -1 -1
+        ```
   validations:
     required: true
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/new_issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/new_issue_template.yml
@@ -7,20 +7,23 @@ body:
 - type: markdown
   attributes:
     value: |
-      Instructions for title: 
-        - Edit the text in the brackets "[ ]". This should be a short "label" for the issue suitable that helps categorize the issue in change log. This should be one to three words, you might even find referencing the existing labels helpful.
-        - Edit the text after the colon ":". This should be a short, descriptive title for the issue.
+      # **Main Issue Information**
+      **Instructions**
+        - Edit the title text above in the brackets "[ ]". This should be a short "label" for the issue suitable that helps categorize the issue in change log. This should be one to three words, you might even find referencing the existing labels (under "labels" in the panel on the right) helpful.
+        - Edit the title text above after the colon ":". This should be a short, descriptive title for the issue.
+        - In the sidebar, add labels that apply to this issue.
+        - Fill out information below and update the summary with pertinent information from the comments/discussion. 
 - type: textarea
   id: describe
   attributes:
-    label: Issue Description
+    label: Issue description
     description: Please provide a description of the issue.
   validations:
     required: true
 - type: textarea
   id: summary
   attributes:
-    label: Summary of Issue History, Discussion, and Major Aspects of Code Development 
+    label: Summary of issue history, discussion, and major aspects of code development 
     description: A summary of pertinent information on this issue, including major aspects of code development, that occurred in the discussion or via email. This section can be added on to/edited at any time and should be completely summarized prior to closing by the person that created the issue.
     placeholder: |
       - This issue is realted to issue #X.
@@ -42,6 +45,12 @@ body:
     value: "- [ ] First Item"
   validations:
     required: true
+- type: markdown
+  attributes:
+    value: |
+      ___
+      
+      # **Other Issue Considerations**
 - type: checkboxes 
   id: documentation
   attributes:

--- a/.github/ISSUE_TEMPLATE/new_issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/new_issue_template.yml
@@ -1,13 +1,15 @@
 name: SS3 Team Issues - New Template
 description: Issue template for SS3 team members ONLY
-title: "[Issue]: Title of Issue Here"
+title: "[Label for Issue Here]: Title of Issue Here"
 assignees:
   - Rick-Methot-NOAA
 body:
 - type: markdown
   attributes:
     value: |
-      Thanks for taking the time to fill out this issue!
+      Instructions for title: 
+        - Edit the text in the brackets "[ ]". This should be a short "label" for the issue suitable that helps categorize the issue in change log. This should be one to three words, you might even find referencing the existing labels helpful.
+        - Edit the text after the colon ":". This should be a short, descriptive title for the issue.
 - type: textarea
   id: describe
   attributes:

--- a/.github/ISSUE_TEMPLATE/new_issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/new_issue_template.yml
@@ -9,7 +9,7 @@ body:
     value: |
       # **Main Issue Information**
       **Instructions**
-        - Edit the title text above in the brackets "[ ]". This should be a short "label" for the issue suitable that helps categorize the issue in change log. This should be one to three words (ex. [Bug], [Feature Request], you might even find referencing the existing labels (under "labels" in the panel on the right) helpful.
+        - Edit the title text above in the brackets "[ ]". This should be a short "label" for the issue suitable that helps categorize the issue in change log. This should be one to three words (ex. [Bug], [Feature Request]), you might even find referencing the existing labels (under "labels" in the panel on the right) helpful.
         - Edit the title text above after the colon ":". This should be a short, descriptive title for the issue.
         - In the sidebar, add labels that apply to this issue.
         - Fill out information below and update the summary with pertinent information from the comments/discussion. 

--- a/.github/ISSUE_TEMPLATE/new_issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/new_issue_template.yml
@@ -72,3 +72,25 @@ body:
       - The following text should be added at the end of the second paragraph in that section: "add text"
   validations:
     required: true
+ - type: checkboxes 
+  id: r4ss
+  attributes: 
+    label: Are r4ss changes needed?
+    description: Please check one of the boxes to indicate if r4ss changes are needed.
+    options:
+      - label: No, this issue doesn't require changes to r4ss
+      - label: Yes, this issue requires changes to r4ss (if checking this box, please add iantaylor-NOAA as an Assignee in the panel to the right).
+      - label: I don't know and would like an r4ss consult (if checking this box, please add iantaylor-NOAA as an Assignee in the panel to the right).
+  validations:
+    required: true
+- type: checkboxes 
+  id: SSI
+  attributes: 
+    label: Are SSI changes needed?
+    description: Please check one of the boxes to indicate if SSI changes are needed.
+    options:
+      - label: No, this issue doesn't require changes to SSI
+      - label: Yes, this issue requires changes to SSI (if checking this box, please add nschindler-noaa as an Assignee in the panel to the right).
+      - label: I don't know and would like an SSI consult (if checking this box, please add nschindler-noaa as an Assignee in the panel to the right).
+  validations:
+    required: true

--- a/.github/ISSUE_TEMPLATE/new_issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/new_issue_template.yml
@@ -9,7 +9,7 @@ body:
     value: |
       # **Main Issue Information**
       **Instructions**
-        - Edit the title text above in the brackets "[ ]". This should be a short "label" for the issue suitable that helps categorize the issue in change log. This should be one to three words, you might even find referencing the existing labels (under "labels" in the panel on the right) helpful.
+        - Edit the title text above in the brackets "[ ]". This should be a short "label" for the issue suitable that helps categorize the issue in change log. This should be one to three words (ex. [Bug], [Feature Request], you might even find referencing the existing labels (under "labels" in the panel on the right) helpful.
         - Edit the title text above after the colon ":". This should be a short, descriptive title for the issue.
         - In the sidebar, add labels that apply to this issue.
         - Fill out information below and update the summary with pertinent information from the comments/discussion. 

--- a/.github/ISSUE_TEMPLATE/new_issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/new_issue_template.yml
@@ -1,6 +1,6 @@
 name: SS3 Team Issues - New Template
 description: Issue template for SS3 team members ONLY
-title: "[Issue]: "
+title: "[Issue]: Title of Issue Here"
 assignees:
   - Rick-Methot-NOAA
 body:
@@ -19,11 +19,11 @@ body:
   id: summary
   attributes:
     label: Summary of Issue History, Discussion, and Major Aspects of Code Development 
-    description: A summary of pertinent information on this issue, including major aspects of code development, that occurred in the discussion/via email. The person creating the issue is responsible for adding info from the discussion to this section.
+    description: A summary of pertinent information on this issue, including major aspects of code development, that occurred in the discussion or via email. This section can be added on to/edited at any time and should be completely summarized prior to closing by the person that created the issue.
     placeholder: |
       - This issue is realted to issue #X.
       - Will need to create an example vignette for this feature.
-      - example input change
+      - Below is example input change.
         ```
         #_MG_type method st_year end_year 
         1 1 2002 2003 # (M) NatMort 
@@ -43,21 +43,21 @@ body:
 - type: checkboxes 
   id: documentation
   attributes:
-    label: Does documentation already exist?
-    description: Please check one of the boxes.
+    label: Does documentation already exist in the SS3 User Manual?
+    description: Please review the [SS3 User Manual](https://nmfs-stock-synthesis.github.io/doc/SS330_User_Manual.html) and check the box that applies.
     options:
-      - label: No, documentation needs to be added and is provided below.
-      - label: Yes, the link to the section in the documentation is provided below.
-      - label: Yes, but further documentation/instruction needs to be added and is provided below.
+      - label: Yes, the link to the section in the SS3 User Manual is provided below.
+      - label: Yes, but further documentation needs to be added and is provided below.
+      - label: No, the documentation that should be added to the SS3 User Manual pertaining to this issue is provided below.
   validations:
     required: true
 - type: textarea
   id: add-doc
   attributes:
-    label: Text to add to SS3 documentation
-    description: Please add the text that needs to be added to the documentation along with which section it should be added to.
+    label: Documentation to add to the SS3 User Manual OR link to existing documentation
+    description: Please add the text that needs to be added to the SS3 User Manual along with which section it should be added to.
     placeholder: |
-      - Documentation can be found in section 8.4.2 of the documentation [here](link)
+      - Documentation can be found in section 8.4.2 of the SS3 User Manual [here](link)
       - The following text should be added at the end of the second paragraph in that section: "add text"
   validations:
     required: true

--- a/.github/ISSUE_TEMPLATE/new_issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/new_issue_template.yml
@@ -1,6 +1,6 @@
 name: SS3 Team Issues - New Template
 description: Issue template for SS3 team members ONLY
-title: "[Label for Issue Here]: Title of Issue Here"
+title: "[Prefix for Issue Here]: Title of Issue Here"
 assignees:
   - Rick-Methot-NOAA
 body:
@@ -9,8 +9,8 @@ body:
     value: |
       # **Main Issue Information**
       **Instructions**
-        - Add a label the title text above in the brackets "[ ]". This should be a short, suitable "label" for the issue that helps categorize the issue in change log. This label should be one to three words (ex. [Bug], [Feature Request]), you might even find referencing the existing labels (under "labels" in the panel on the right) helpful.
-        - Add a title to the title text above after the colon ":". This should be a short, descriptive title for the issue.
+        - Add a label prefix in the brackets "[ ]". This should be 1 - 2 words that helps categorize the issue (e.g. [Bug], [Feature Request], [Refactor]).
+        - Add a title after the colon ":". This should be a short phrase that describes the issue. It should be suitable for display in the change log.
         - In the sidebar, add labels that apply to this issue.
         - Fill out information below and update the summary with pertinent information from the comments/discussion. 
 - type: textarea
@@ -26,7 +26,7 @@ body:
     label: Summary of issue history, discussion, and major aspects of code development 
     description: A summary of pertinent information on this issue, including major aspects of code development, that occurred in the discussion or via email. This section can be added on to/edited at any time and should be completely summarized prior to closing by the person that created the issue.
     placeholder: |
-      - This issue is realted to issue #X.
+      - This issue is related to issue #X.
       - Will need to create an example vignette for this feature.
       - Below is example input change.
         ```

--- a/.github/ISSUE_TEMPLATE/new_issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/new_issue_template.yml
@@ -1,0 +1,53 @@
+name: SS3 Team Issues - New Template
+description: Issue template for SS3 team members ONLY
+title: "[Issue]: "
+assignees:
+  - Rick-Methot-NOAA
+body:
+- type: markdown
+  attributes:
+    value: |
+      Thanks for taking the time to fill out this issue!
+- type: textarea
+  id: describe
+  attributes:
+    label: Issue Description
+    description: Please provide a description of the issue.
+  validations:
+    required: true
+- type: textarea
+  id: summary
+  attributes:
+    label: Summary of Issue History and Discussion 
+    description: A summary of pertinent information on this issue that occurred in the discussion or via email. The person creating the issue is responsible for adding info from the discussion to this section.
+  validations:
+    required: true
+- type: textarea
+  id: tasks
+  attributes:
+    label: Items to do
+    description: Please create a list of tasks to be completed for this issue with the checkboxes.
+    value: "- [ ] First Item"
+  validations:
+    required: true
+- type: checkboxes 
+  id: documentation
+  attributes:
+    label: Does documentation already exist?
+    description: Please check one of the boxes.
+    options:
+      - label: No, documentation needs to be added and is provided below.
+      - label: Yes, the link to the section in the documentation is provided below.
+      - label: Yes, but further documentation/instruction needs to be added and is provided below.
+  validations:
+    required: true
+- type: textarea
+  id: add-doc
+  attributes:
+    label: Text to add to SS3 documentation
+    description: Please add the text that needs to be added to the documentation along with which section it should be added to.
+    placeholder: |
+      - Documentation can be found in section 8.4.2 of the documentation [here](link)
+      - The following text should be added at the end of the second paragraph in that section: "add text"
+  validations:
+    required: true

--- a/.github/ISSUE_TEMPLATE/new_issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/new_issue_template.yml
@@ -9,8 +9,8 @@ body:
     value: |
       # **Main Issue Information**
       **Instructions**
-        - Edit the title text above in the brackets "[ ]". This should be a short "label" for the issue suitable that helps categorize the issue in change log. This should be one to three words (ex. [Bug], [Feature Request]), you might even find referencing the existing labels (under "labels" in the panel on the right) helpful.
-        - Edit the title text above after the colon ":". This should be a short, descriptive title for the issue.
+        - Add a label the title text above in the brackets "[ ]". This should be a short, suitable "label" for the issue that helps categorize the issue in change log. This label should be one to three words (ex. [Bug], [Feature Request]), you might even find referencing the existing labels (under "labels" in the panel on the right) helpful.
+        - Add a title to the title text above after the colon ":". This should be a short, descriptive title for the issue.
         - In the sidebar, add labels that apply to this issue.
         - Fill out information below and update the summary with pertinent information from the comments/discussion. 
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/new_issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/new_issue_template.yml
@@ -72,7 +72,7 @@ body:
       - The following text should be added at the end of the second paragraph in that section: "add text"
   validations:
     required: true
- - type: checkboxes 
+- type: checkboxes 
   id: r4ss
   attributes: 
     label: Are r4ss changes needed?


### PR DESCRIPTION
@Rick-Methot-NOAA asked for a new issue template that would allow for a place to put a summary of the discussion that happens throughout the lifecycle of an issue. I created this template more for internal use as there is a new feature and bug issue template. Those can be updated as well but wanted to have a custom template for people to use as many issues don't fall in the feature request or bug categories. I added a section about documentation to make sure that updating/sufficient documentation is on everyones minds.

To see this issue template 'in action' refer to @e-gugliotti-NOAA's github-actions-test repo linked [here](https://github.com/e-gugliotti-NOAA/github-actions-test/issues/new?assignees=e-gugliotti-NOAA&labels=&template=ss3-team-template.yml&title=%5BIssue%5D). 

Please provide any suggestions/edits that you have. I can definitely add sections such as "To Reproduce", or "SS3 Version", I just started off simple so that there wasn't an overwhelming amount of fields right off the bat.

## Please Link issue(s)
@Rick-Methot-NOAA referenced the format in issue #68
resolves #[add issue number number], resolves #[optional second issue number if more than 1 issue addressed.]
