### PR TITLE
Revised pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,18 +6,22 @@ Resolves #[add issue number] and #[add optional second issue number].
 
 ## What tests have been done? Upload any model input files created for testing in a zip file, if possible.
 <!--- If this pull request is related to an issue, please include these test files in the summary of that issue.-->
- - [ ] These tests files are in the issue.
- - [ ] There is no issue related to this pull request so the files are attached.
- - [ ] No test files are required for this issue.
+<!--- Please copy the appropriate response from the list below and paste it under the checkbox.--->
+<!--- - These tests files are in the issue.--->
+<!--- - There is no issue related to this pull request so the files are attached.--->
+<!--- - No test files are required for this issue.--->
+ - [ ] Information on tests is below:
 
 ### What tests/review still need to be done? Who can do it, and by when is it needed (ideally)?
 <!--- Tests/review and associated files go here. If none are needed, please put None.-->
 
 ## Is there an input change for users to Stock Synthesis? 
 <!--- If this pull request is related to an issue, please include that the input change is in the summary of that issue.-->
-- [ ] The input change is in the issue summary.
-- [ ] There is no issue related to this pull request so the input change is below.
-- [ ] No, there was no input change.
+<!--- Please copy the appropriate response from the list below and paste it under the checkbox.--->
+<!--- - The input change is in the issue summary.--->
+<!--- - There is no issue related to this pull request so the input change is below.--->
+<!--- - No, there was no input change.--->
+ - [ ] Information on input change is below:
 
 <!--- ```
 If there is no issue related to this pull request, example stock synthesis input goes here. 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,31 +1,43 @@
+<!-- General instructions -->
+<!--
+* Please read the html comment under each heading and follow the instructions.
+* For smaller changes, feel free to skip sections flagged as "optional".
+* Before opening the pull request (PR), make sure all the GitHub actions are
+  passing on the remote feature branch.
+* Make sure this PR has an informative title rather than the default text.
+* Lastly, before closing the PR, **please make sure that all comments/discussion in this PR that are related to an issue are placed in the summary of that issue**.
+-->
+
 ## Concisely describe what has been changed/addressed in the pull request.
 <!--- In less than 20 words describe this pull request and link related issues.-->
-<!--- Please make sure that all comments/discussion in this pull request that are related to an issue are placed in the summary of that issue.-->
 <!--- A summary is very important if there is no issue related to the pull request, otherwise most of the summary should be in the issue.-->
-Resolves #[add issue number] and #[add optional second issue number].
 
-## What tests have been done? Upload any model input files created for testing in a zip file, if possible.
-<!--- If this pull request is related to an issue, please include these test files in the summary of that issue.-->
-<!--- Please copy the appropriate response from the list below and paste it under the checkbox.--->
-<!--- - These tests files are in the issue.--->
-<!--- - There is no issue related to this pull request so the files are attached.--->
-<!--- - No test files are required for this issue.--->
- - [ ] Information on tests is below:
 
-### What tests/review still need to be done? Who can do it, and by when is it needed (ideally)?
-<!--- Tests/review and associated files go here. If none are needed, please put None.-->
+<!-- Link related issues using a bulleted list. -->
+<!-- Use additional bullets to link more issues. -->
+<!-- Remove the following bullet if no issues are linked to this PR. -->
+* Resolves issue #
+
+## What tests have been done? 
+### Where are the relevant files?
+<!-- Uncomment the option below that best fits the situation. -->
+<!-- - [x] Test files are in the issue. -->
+<!-- - [x] There is no issue related to this pull request so the files are attached below. -->
+<!-- - [x] No test files are required for this pull request. -->
+
+### What tests/review still need to be done?
+<!-- Upload any model input files created for testing in a zip file, if possible. -->
+<!-- If no additional tests are needed, please put None.-->
+<!-- Provide information on who/when for uncompleted tasks -->
 
 ## Is there an input change for users to Stock Synthesis? 
-<!--- If this pull request is related to an issue, please include that the input change is in the summary of that issue.-->
-<!--- Please copy the appropriate response from the list below and paste it under the checkbox.--->
-<!--- - The input change is in the issue summary.--->
-<!--- - There is no issue related to this pull request so the input change is below.--->
-<!--- - No, there was no input change.--->
- - [ ] Information on input change is below:
+<!-- Uncomment the option below that best fits the situation. -->
+<!-- - [x] The input change is in the issue summary. -->
+<!-- - [x] There is no issue related to this pull request so the input change is below. -->
+<!-- - [x] No, there was no input change. -->
 
 <!--- ```
-If there is no issue related to this pull request, example stock synthesis input goes here. 
-Otherwise, delete code chunk.
+If there is no issue related to this pull request, example stock synthesis input goes here.
 ``` -->
 
 ## Additional information (optional):

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,29 +1,28 @@
-## Concisely (20 words or less) describe what has been changed/addressed in the pull request and link related issues.
-***Please make sure that all comments/discussion in this pull request that is related to an issue gets put in the summary of that issue.** \
-***A summary is very important if there is no issue related to the pull request, otherwise most of the summary should be in the issue.**
-> Short summary goes here. \
-> Resolves #[add issue number] and #[add optional second issue number].
+## Concisely describe what has been changed/addressed in the pull request.
+<!--- In less than 20 words describe this pull request and link related issues.-->
+<!--- Please make sure that all comments/discussion in this pull request that are related to an issue are placed in the summary of that issue.-->
+<!--- A summary is very important if there is no issue related to the pull request, otherwise most of the summary should be in the issue.-->
+Resolves #[add issue number] and #[add optional second issue number].
 
 ## What tests have been done? Upload any model input files created for testing in a zip file, if possible.
-**If this pull request is related to an issue, please include these test files in the summary of that issue.**
+<!--- If this pull request is related to an issue, please include these test files in the summary of that issue.-->
  - [ ] These tests files are in the issue.
  - [ ] There is no issue related to this pull request so the files are attached.
  - [ ] No test files are required for this issue.
 
 ### What tests/review still need to be done? Who can do it, and by when is it needed (ideally)?
-> Tests/review and associated files go here.
+<!--- Tests/review and associated files go here. If none are needed, please put None.-->
 
 ## Is there an input change for users to Stock Synthesis? 
-**If this pull request is related to an issue, please include that the input change is in the summary of that issue.**
-
+<!--- If this pull request is related to an issue, please include that the input change is in the summary of that issue.-->
 - [ ] The input change is in the issue summary.
 - [ ] There is no issue related to this pull request so the input change is below.
 - [ ] No, there was no input change.
 
-```
+<!--- ```
 If there is no issue related to this pull request, example stock synthesis input goes here. 
 Otherwise, delete code chunk.
-```
+``` -->
 
 ## Additional information (optional):
-> Any additional information goes here.
+<!--- Any additional information goes here. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,36 +9,39 @@
 -->
 
 ## Concisely describe what has been changed/addressed in the pull request.
-<!--- In less than 20 words describe this pull request and link related issues.-->
-<!--- A summary is very important if there is no issue related to the pull request, otherwise most of the summary should be in the issue.-->
+<!--- In less than 20 words describe this PR and link related issues.-->
+<!--- A summary is important if there is no issue related to the PR, otherwise the summary should be in the issue.-->
 
 
-<!-- Link related issues using a bulleted list. -->
-<!-- Use additional bullets to link more issues. -->
+<!-- Link related issue(s) using a bulleted list. -->
 <!-- Remove the following bullet if no issues are linked to this PR. -->
 * Resolves issue #
 
 ## What tests have been done? 
 ### Where are the relevant files?
-<!-- Uncomment the option below that best fits the situation. -->
+<!-- Uncomment the option below that best fits the situation and upload the necessary files to the correct location, preferabbly the associated issue(s). -->
+
 <!-- - [x] Test files are in the issue. -->
 <!-- - [x] There is no issue related to this pull request so the files are attached below. -->
 <!-- - [x] No test files are required for this pull request. -->
 
 ### What tests/review still need to be done?
-<!-- Upload any model input files created for testing in a zip file, if possible. -->
 <!-- If no additional tests are needed, please put None.-->
 <!-- Provide information on who/when for uncompleted tasks -->
 
 ## Is there an input change for users to Stock Synthesis? 
 <!-- Uncomment the option below that best fits the situation. -->
-<!-- - [x] The input change is in the issue summary. -->
+<!-- If needed, uncomment the code block and replace the text. -->
+
+<!-- - [x] The input change is in the related issue(s). -->
 <!-- - [x] There is no issue related to this pull request so the input change is below. -->
 <!-- - [x] No, there was no input change. -->
 
-<!--- ```
-If there is no issue related to this pull request, example stock synthesis input goes here.
-``` -->
+<!---
+```
+If there is no issue related to this PR, replace this text with your example stock synthesis input.
+```
+-->
 
-## Additional information (optional):
+## Additional information (optional).
 <!--- Any additional information goes here. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,43 +1,29 @@
-## Concisely (20 words or less) describe the issue
-
-## Please Link issue(s)
-
-resolves #[add issue number number], resolves #[optional second issue number if more than 1 issue addressed.]
+## Concisely (20 words or less) describe what has been changed/addressed in the pull request and link related issues.
+***Please make sure that all comments/discussion in this pull request that is related to an issue gets put in the summary of that issue.** \
+***A summary is very important if there is no issue related to the pull request, otherwise most of the summary should be in the issue.**
+> Short summary goes here. \
+> Resolves #[add issue number] and #[add optional second issue number].
 
 ## What tests have been done? Upload any model input files created for testing in a zip file, if possible.
+**If this pull request is related to an issue, please include these test files in the summary of that issue.**
+ - [ ] These tests files are in the issue.
+ - [ ] There is no issue related to this pull request so the files are attached.
+ - [ ] No test files are required for this issue.
 
-## What tests/review still need to be done? Who can do it, and by when is it needed (ideally)?
+### What tests/review still need to be done? Who can do it, and by when is it needed (ideally)?
+> Tests/review and associated files go here.
 
-## Has any new code been documented?
+## Is there an input change for users to Stock Synthesis? 
+**If this pull request is related to an issue, please include that the input change is in the summary of that issue.**
 
-If not, please add documentation before submitting the Pull Request.
-- [ ] I have documented any new code added (or no new code was added)
-
-## is there an input change for users to Stock Synthesis? 
-
-- [ ] Yes, there was an input change
-
-If so, please provide an example of the new inputs needed.
-
-```
-[New example stock synthesis input goes here]
+- [ ] The input change is in the issue summary.
+- [ ] There is no issue related to this pull request so the input change is below.
+- [ ] No, there was no input change.
 
 ```
-
-## Check which is true. This PR requires:
-
-- [ ] no further changes to r4ss
-- [ ] no further changes to the manual
-- [ ] no further changes to SSI (the SS3 GUI)
-- [ ] no further changes to the stock synthesis change log (new features, bug reports)
-
-## Describe any changes in r4ss/SS3 manual/SSI that are needed (if not checked):
-
-## If changes are needed in the change log, please fill in the table here:
-
-| Action                | Topics                                     | Type  |
-| --------------------- | ----------------------------------------- | --------------------------------------- |
-| [fix, new, or revise] | [e.g., biology. Use issue label options.] | [input, output, and/or calc, or ALL] |
-
+If there is no issue related to this pull request, example stock synthesis input goes here. 
+Otherwise, delete code chunk.
+```
 
 ## Additional information (optional):
+> Any additional information goes here.


### PR DESCRIPTION
Simplified the pull request template with redundancies from the issue template (see pr #433) for changes to issue template). Can add those sections back if requested. If you would like to see the example pull request "in action", it is available in a repo of mine [here](https://github.com/e-gugliotti-NOAA/github-actions-test/pull/4).

Major changes to note are: 
1. I removed the doc/r4ss/ssi section. With this change, Issues will not automatically be created in those repos from a pull request or from an issue. It seemed like this feature wasn't working for everyone which is why it was removed, however I'm open to suggestions/putting it back in if people do like that feature. 
2. I removed the section to revise the change log if needed. It didn't look like this feature was being used plus with us moving to keeping most info in the issue, it seemed unnecessary, but again, if this feature is useful, I will gladly put it back in.
3. Making changes 1 & 2 will make [this workflow](https://github.com/nmfs-stock-synthesis/stock-synthesis/blob/main/.github/workflows/ss3-pr-open-issues.yml) redundant and would be removed if everyone agrees on the changes above.
4. I used block quotes for free text input sections
   > Example here. This was a stylistic choice as I personally thought it looked better than having plain text.

Please review and provide any comments/suggestions.