### PR TITLE
Fixes #437 regarding partition warning

### DIFF
--- a/SS_prelim.tpl
+++ b/SS_prelim.tpl
@@ -1131,6 +1131,7 @@
       for (i = 1; i <= Nobs_l(f); i++)
       {
         parti_cnt(abs(mkt_l(f, i)))++;
+        if (Do_Retain(f) == 0) mkt_l(f,i) = 0;  //  force to partition 0 if retention not defined
       }
       if (parti_cnt(1) > 0 && Do_Retain(f) == 0)
       {
@@ -1139,7 +1140,7 @@
       }
       if (parti_cnt(2) > 0 && Do_Retain(f) == 0)
       {
-        warnstream <<  "fleet: " << f << "  lencomp has obs with partition==2; will treat as partition=0 because retention not defined; N= " << parti_cnt(2);
+        warnstream <<  "fleet: " << f << " lencomp has N obs with partition==2 (retained); changed to partition=0 because retention not defined; N= " << parti_cnt(2);
         write_message (WARN, 0);
       }
       if (parti_cnt(2) > 0 && (fleet_type(f) == 2 || seltype(f, 2) == 3 || seltype(Nfleet + f, 2) == 3)) //  error if retained catch obs are with no retention fleets
@@ -1155,6 +1156,7 @@
       for (i = 1; i <= Nobs_a(f); i++)
       {
         parti_cnt(abs(mkt_a(f, i)))++;
+        if (Do_Retain(f) == 0) mkt_a(f,i) = 0;  //  force to partition 0 if retention not defined
       }
       if (parti_cnt(1) > 0 && Do_Retain(f) == 0)
       {
@@ -1163,7 +1165,7 @@
       }
       if (parti_cnt(2) > 0 && Do_Retain(f) == 0)
       {
-        warnstream << "Fleet: " << f << "  agecomp has obs with partition==2; will treat as partition=0 because retention not defined; N= " << parti_cnt(2);
+        warnstream << "Fleet: " << f << "  agecomp has N obs with partition==2 (retained); changed to partition=0 because retention not defined; N= " << parti_cnt(2);
         write_message (WARN, 0);
       }
       if (parti_cnt(2) > 0 && (fleet_type(f) == 2 || seltype(f, 2) == 3 || seltype(Nfleet + f, 2) == 3)) //  error if retained catch obs are with no retention fleets
@@ -1179,7 +1181,8 @@
       for (i = 1; i <= Nobs_ms(f); i++)
       {
         parti_cnt(abs(mkt_ms(f, i)))++;
-      }
+        if (Do_Retain(f) == 0) mkt_ms(f, i) = 0;  //  force to partition 0 if retention not defined
+    }
       if (parti_cnt(1) > 0 && Do_Retain(f) == 0)
       {
         warnstream << "Fleet: " << f << "  size-at-age data contains obs with partition==1 and retention fxn not defined; N= " << parti_cnt(1);
@@ -1187,7 +1190,7 @@
       }
       if (parti_cnt(2) > 0 && Do_Retain(f) == 0)
       {
-        warnstream << "Fleet: " << f << "  size-at-age data  has obs with partition==2; will treat as partition=0 because retention not defined; N= " << parti_cnt(2);
+        warnstream << "Fleet: " << f << "  size-at-age data has N obs with partition==2 (retained); changed to partition=0 because retention not defined; N= " << parti_cnt(2);
         write_message (WARN, 0);
       }
       if (parti_cnt(2) > 0 && (fleet_type(f) == 2 || seltype(f, 2) == 3 || seltype(Nfleet + f, 2) == 3)) //  error if retained catch obs are with no retention fleets
@@ -1207,6 +1210,7 @@
         {
           int parti = abs(mnwtdata(4, i)); //  partition:  0=all, 1=discard, 2=retained
           parti_cnt(parti)++;
+          if (Do_Retain(f) == 0) mnwtdata(4, i) = 0;  //  force to partition 0 if retention not defined
         }
       }
       if (parti_cnt(1) > 0 && Do_Retain(f) == 0)
@@ -1216,7 +1220,7 @@
       }
       if (parti_cnt(2) > 0 && Do_Retain(f) == 0)
       {
-        warnstream << "Fleet: " << f << "  meansize data has obs with partition==2; will treat as partition=0 because retention not defined; N= " << parti_cnt(2);
+        warnstream << "Fleet: " << f << "  meansize data has N obs with partition==2 (retained); changed to partition=0 because retention not defined; N= " << parti_cnt(2);
         write_message (WARN, 0);
       }
       if (parti_cnt(2) > 0 && (fleet_type(f) == 2 || seltype(f, 2) == 3 || seltype(Nfleet + f, 2) == 3)) //  error if retained catch obs are with no retention fleets

--- a/SS_prelim.tpl
+++ b/SS_prelim.tpl
@@ -1166,7 +1166,7 @@
       if (parti_cnt(2) > 0 && Do_Retain(f) == 0)
       {
         warnstream << "Fleet: " << f << "  agecomp has N obs with partition==2 (retained); changed to partition=0 because retention not defined; N= " << parti_cnt(2);
-        write_message (WARN, 0);
+        write_message (ADJUST, 0);
       }
       if (parti_cnt(2) > 0 && (fleet_type(f) == 2 || seltype(f, 2) == 3 || seltype(Nfleet + f, 2) == 3)) //  error if retained catch obs are with no retention fleets
       {
@@ -1191,7 +1191,7 @@
       if (parti_cnt(2) > 0 && Do_Retain(f) == 0)
       {
         warnstream << "Fleet: " << f << "  size-at-age data has N obs with partition==2 (retained); changed to partition=0 because retention not defined; N= " << parti_cnt(2);
-        write_message (WARN, 0);
+        write_message (ADJUST, 0);
       }
       if (parti_cnt(2) > 0 && (fleet_type(f) == 2 || seltype(f, 2) == 3 || seltype(Nfleet + f, 2) == 3)) //  error if retained catch obs are with no retention fleets
       {
@@ -1221,7 +1221,7 @@
       if (parti_cnt(2) > 0 && Do_Retain(f) == 0)
       {
         warnstream << "Fleet: " << f << "  meansize data has N obs with partition==2 (retained); changed to partition=0 because retention not defined; N= " << parti_cnt(2);
-        write_message (WARN, 0);
+        write_message (ADJUST, 0);
       }
       if (parti_cnt(2) > 0 && (fleet_type(f) == 2 || seltype(f, 2) == 3 || seltype(Nfleet + f, 2) == 3)) //  error if retained catch obs are with no retention fleets
       {

--- a/SS_readdata_330.tpl
+++ b/SS_readdata_330.tpl
@@ -1839,7 +1839,7 @@
   imatrix  gen_l(1,Nfleet,1,Nobs_l);
   imatrix  mkt_l(1,Nfleet,1,Nobs_l);
   3darray header_l_rd(1,Nfleet,1,Nobs_l,0,3);
-  3darray header_l(1,Nfleet,1,Nobs_l,0,3);
+  3darray header_l(1,Nfleet,1,Nobs_l,0,5);
   3darray tails_l(1,Nfleet,1,Nobs_l,1,4); // min-max bin for females; min-max bin for males
   ivector tails_w(1,4);
 
@@ -1929,7 +1929,8 @@
             }
 
             header_l_rd(f, j)(1, 3) = lendata[i](1, 3); // values as in input file
-            header_l(f, j, 3) = lendata[i](3);
+//            header_l(f, j, 3) = lendata[i](3);
+            header_l(f, j)(3, 5) = lendata[i](3, 5);
             if (y > retro_yr)
               header_l(f, j, 3) = -f;
             if (header_l(f, j, 3) > 0)

--- a/SS_readdata_330.tpl
+++ b/SS_readdata_330.tpl
@@ -1838,8 +1838,8 @@
   matrix  nsamp_l_read(1,Nfleet,1,Nobs_l);
   imatrix  gen_l(1,Nfleet,1,Nobs_l);
   imatrix  mkt_l(1,Nfleet,1,Nobs_l);
-  3darray header_l_rd(1,Nfleet,1,Nobs_l,0,3);
-  3darray header_l(1,Nfleet,1,Nobs_l,0,5);
+  3darray header_l_rd(1,Nfleet,1,Nobs_l,0,5);
+  3darray header_l(1,Nfleet,1,Nobs_l,0,3);
   3darray tails_l(1,Nfleet,1,Nobs_l,1,4); // min-max bin for females; min-max bin for males
   ivector tails_w(1,4);
 
@@ -1928,9 +1928,9 @@
               header_l(f, j, 2) = timing_r_result(1); // month
             }
 
-            header_l_rd(f, j)(1, 3) = lendata[i](1, 3); // values as in input file
-//            header_l(f, j, 3) = lendata[i](3);
-            header_l(f, j)(3, 5) = lendata[i](3, 5);
+            header_l_rd(f, j)(1, 5) = lendata[i](1, 5); // values as in input file
+            header_l(f, j, 3) = lendata[i](3);
+//            header_l(f, j)(3, 5) = lendata[i](3, 5);
             if (y > retro_yr)
               header_l(f, j, 3) = -f;
             if (header_l(f, j, 3) > 0)

--- a/SS_write_ssnew.tpl
+++ b/SS_write_ssnew.tpl
@@ -14,7 +14,10 @@ FUNCTION void write_nudata()
   int compindex = 0;
   dvector temp_probs2(1, n_abins2);
   int Nudat = 0;
+  int Nubootdat = 0;
   int Nsamp_DM = 0;
+  adstring newdatfilename;
+  adstring datinfostring;
   //  create bootstrap data files; except first file just replicates the input and second is the estimate without error
   if (irand_seed < 0)
     irand_seed = long(time(&start));
@@ -30,50 +33,46 @@ FUNCTION void write_nudata()
     if (Nudat == 1)
     {
       echoinput << "Begin writing data_echo.ss_new file" << endl;
-      anystring = ssnew_pathname + "data_echo.ss_new";
-      report1.open(anystring);
-      report1 << version_info(1) << version_info(2) << version_info(3) << endl
-              << version_info2 << endl
-              << "#_Start_time: " << ctime(&start);
-      report1 << "#_echo_input_data" << endl;
-      report1 << Data_Comments << endl;
+      newdatfilename = "data_echo.ss_new";
+	  datinfostring = "echo_input_data";
     }
     else if (Nudat == 2)
     {
       echoinput << "Begin writing data_expval.ss file" << endl;
-      anystring = ssnew_pathname + "data_expval.ss";
-      report1.open(anystring);
-      report1 << version_info(1) << version_info(2) << version_info(3) << endl
-              << version_info2 << endl
-              << "#_Start_time: " << ctime(&start);
-      report1 << "#_expected_values" << endl;
-      report1 << Data_Comments << endl;
+      newdatfilename = "data_expval.ss";
+	  datinfostring = "expected_values";
     }
-    else
+    else // data_boot files
     {
       echoinput << "Begin writing bootstrap data file(s)" << endl;
-      anystring = "     ";
-      sprintf(anystring, "%d", Nudat - 2);
-      if ((Nudat - 2) < 10)
+      Nubootdat = Nudat - 2;
+      anystring2 = "     ";
+      sprintf(anystring2, "%d", Nubootdat);
+      if (Nubootdat < 10)
       {
-        anystring2 = ssnew_pathname + "data_boot_00" + anystring + ".ss";
+        newdatfilename = "data_boot_00" + anystring2 + ".ss";
       }
-      else if ((Nudat - 2) < 100)
+      else if (Nubootdat < 100)
       {
-        anystring2 = ssnew_pathname + "data_boot_0" + anystring + ".ss";
+        newdatfilename = "data_boot_0" + anystring2 + ".ss";
       }
-      else
+      else // Nubootdat > 99
       {
-        anystring2 = ssnew_pathname + "data_boot_" + anystring + ".ss";
+        newdatfilename = "data_boot_" + anystring2 + ".ss";
       }
-      report1.open(anystring2);
-      report1 << version_info(1) << version_info(2) << version_info(3) << endl
-              << version_info2 << endl
-              << "#_Start_time: " << ctime(&start);
-      report1 << "#_bootdata:_" << Nudat << endl;
-      report1 << Data_Comments << endl;
-      report1 << "#_bootstrap file: " << Nudat - 2 << "  irand_seed: " << irand_seed << " first rand#: " << randn(radm) << endl;
+	  datinfostring = "  ";
+	  sprintf(datinfostring, "bootdata:_%d", Nudat);
     }
+    anystring = ssnew_pathname + newdatfilename;
+    report1.open(anystring);
+    report1 << version_info(1) << version_info(2) << version_info(3) << endl
+            << version_info2 << endl
+            << "#_Start_time: " << ctime(&start);
+    report1 << "#_" << datinfostring << endl;
+    report1 << Data_Comments << endl;
+	if (Nudat > 2)
+	  report1 << "#_bootstrap file: " << Nubootdat << "  irand_seed: " << irand_seed << " first rand#: " << randn(radm) << endl;
+
     report1 << version_info(1) << version_info(2) << version_info(3) << endl;
     report1 << styr << " #_StartYr" << endl;
     report1 << endyr << " #_EndYr" << endl;

--- a/SS_write_ssnew.tpl
+++ b/SS_write_ssnew.tpl
@@ -656,7 +656,7 @@ FUNCTION void write_nudata()
               if (nsamp_l(f, i) < k)
                 k = nsamp_l(f, i);
               exp_l_temp_dat = nsamp_l(f, i) * value(exp_l(f, i) / sum(exp_l(f, i)));
-              report1 << header_l_rd(f, i)(1, 3) << " " << gen_l(f, i) << " " << header_l(f, i)(5) << " " << nsamp_l(f, i) << " " << exp_l_temp_dat << endl;
+              report1 << header_l_rd(f, i)(1, 3) << " " << gen_l(f, i) << " " << header_l_rd(f, i)(5) << " " << nsamp_l(f, i) << " " << exp_l_temp_dat << endl;
             }
           }
         }
@@ -1135,7 +1135,8 @@ FUNCTION void write_nudata()
                 exp_l_temp_dat(temp_mult(compindex)) += 1.0;
               }
 
-              report1 << header_l_rd(f, i)(1, 3) << " " << gen_l(f, i) << " " << header_l(f, i)(5) << " " << Nsamp_DM << " " << exp_l_temp_dat << endl;
+              report1 << header_l_rd(f, i)(1, 5) << " " << Nsamp_DM << " " << exp_l_temp_dat << endl;
+//              report1 << header_l_rd(f, i)(1, 3) << " " << gen_l(f, i) << " " << header_l_rd(f, i)(5) << " " << Nsamp_DM << " " << exp_l_temp_dat << endl;
             }
           }
         }

--- a/SS_write_ssnew.tpl
+++ b/SS_write_ssnew.tpl
@@ -656,7 +656,7 @@ FUNCTION void write_nudata()
               if (nsamp_l(f, i) < k)
                 k = nsamp_l(f, i);
               exp_l_temp_dat = nsamp_l(f, i) * value(exp_l(f, i) / sum(exp_l(f, i)));
-              report1 << header_l_rd(f, i)(1, 3) << " " << gen_l(f, i) << " " << mkt_l(f, i) << " " << nsamp_l(f, i) << " " << exp_l_temp_dat << endl;
+              report1 << header_l_rd(f, i)(1, 3) << " " << gen_l(f, i) << " " << header_l(f, i)(5) << " " << nsamp_l(f, i) << " " << exp_l_temp_dat << endl;
             }
           }
         }
@@ -1135,7 +1135,7 @@ FUNCTION void write_nudata()
                 exp_l_temp_dat(temp_mult(compindex)) += 1.0;
               }
 
-              report1 << header_l_rd(f, i)(1, 3) << " " << gen_l(f, i) << " " << mkt_l(f, i) << " " << Nsamp_DM << " " << exp_l_temp_dat << endl;
+              report1 << header_l_rd(f, i)(1, 3) << " " << gen_l(f, i) << " " << header_l(f, i)(5) << " " << Nsamp_DM << " " << exp_l_temp_dat << endl;
             }
           }
         }


### PR DESCRIPTION
## Concisely (20 words or less) describe the issue
revision of output when compdata read with 2 as retained, but retention not defined
## Please Link issue(s)
#437
resolves #437 
## What tests have been done? Upload any model input files created for testing in a zip file, if possible.
eyeball test 
## What tests/review still need to be done? Who can do it, and by when is it needed (ideally)?
code is not consistent regarding ssnew files.  Data.echo OK, but for other new files need to decide if the original or transformed partition code should be output.  lencomp writes out the revised value of mkt_l(f,i), but agecomp and meansize write out saved value of header_a which is a vector containing the original value of mkt_a, etc.
## Has any new code been documented?
yes
If not, please add documentation before submitting the Pull Request.
- [ ] I have documented any new code added (or no new code was added)

## is there an input change for users to Stock Synthesis? 

- [ ] Yes, there was an input change

If so, please provide an example of the new inputs needed.

```
[New example stock synthesis input goes here]

```

## Check which is true. This PR requires:

- [ ] no further changes to r4ss
- [ ] no further changes to the manual
- [ ] no further changes to SSI (the SS3 GUI)
- [ ] no further changes to the stock synthesis change log (new features, bug reports)

## Describe any changes in r4ss/SS3 manual/SSI that are needed (if not checked):

## If changes are needed in the change log, please fill in the table here:

| Action                | Topics                                     | Type  |
| --------------------- | ----------------------------------------- | --------------------------------------- |
| [fix, new, or revise] | [e.g., biology. Use issue label options.] | [input, output, and/or calc, or ALL] |


## Additional information (optional):
