### PR TITLE
restoration of 3rd parameter for SRR=7

### DIFF
--- a/SS_recruit.tpl
+++ b/SS_recruit.tpl
@@ -343,11 +343,9 @@ FUNCTION dvar_vector Equil_Spawn_Recr_Fxn(const prevariable& SRparm2, const prev
     {
       SRZ_0 = log(1.0 / (SSB_virgin / Recr_virgin));
       srz_min = SRZ_0 * (1.0 - steepness);
-      B_equil = SSB_virgin * (1. - (log(1. / SPR_temp) - SRZ_0) / pow((srz_min - SRZ_0), (1. / 1.)));
+      B_equil = SSB_virgin * (1. - (log(1. / SPR_temp) - SRZ_0) / pow((srz_min - SRZ_0), (1. / SRparm3)));
       B_equil = posfun(B_equil, 0.0001, temp);
-      SRZ_surv = mfexp((1. - pow((B_equil / SSB_virgin), 1.)) * (srz_min - SRZ_0) + SRZ_0); //  survival
-//      B_equil = SSB_virgin * (1. - (log(1. / SPR_temp) - SRZ_0) / pow((srz_min - SRZ_0), (1. / SRparm3)));
-//      SRZ_surv = mfexp((1. - pow((B_equil / SSB_virgin), SRparm3)) * (srz_min - SRZ_0) + SRZ_0); //  survival
+      SRZ_surv = mfexp((1. - pow((B_equil / SSB_virgin), SRparm3)) * (srz_min - SRZ_0) + SRZ_0); //  survival
       R_equil = B_equil * SRZ_surv;
       break;
     }


### PR DESCRIPTION
## Concisely (20 words or less) describe the issue

## Please Link issue(s)
#443 
resolves #[add issue number number], resolves #[optional second issue number if more than 1 issue addressed.]
#443 
## What tests have been done? Upload any model input files created for testing in a zip file, if possible.
verify that variance is produced when using SRR=7 and beta not equal to 1.0
## What tests/review still need to be done? Who can do it, and by when is it needed (ideally)?
none

- [X] I have documented any new code added (or no new code was added)

## is there an input change for users to Stock Synthesis? 

- [ ] Yes, there was an input change

If so, please provide an example of the new inputs needed.

```
[New example stock synthesis input goes here]

```

## Check which is true. This PR requires:

- [X] no further changes to r4ss
- [X] no further changes to the manual
- [X] no further changes to SSI (the SS3 GUI)
- [ ] no further changes to the stock synthesis change log (new features, bug reports)

## Describe any changes in r4ss/SS3 manual/SSI that are needed (if not checked):

## If changes are needed in the change log, please fill in the table here:

| Action                | Topics                                     | Type  |
| --------------------- | ----------------------------------------- | --------------------------------------- |
| [fix, new, or revise] | [e.g., biology. Use issue label options.] | [input, output, and/or calc, or ALL] |


## Additional information (optional):
