### PR TITLE
Fcast MGparm averaging year value checks

### DIFF
--- a/SS_readdata_330.tpl
+++ b/SS_readdata_330.tpl
@@ -4240,7 +4240,7 @@
           else if (Fcast_MGparm_ave_rd(i,3) >= endyr)
           {
             Fcast_MGparm_ave(i,3) = endyr - 1;
-            warnstream << "start year exceeds endyr, setting start year to: " << Fcast_MGparm_ave(i,3);
+            warnstream << "Fcast_MGparm_ave start year exceeds endyr, setting start year to: " << Fcast_MGparm_ave(i,3);
             write_message(ADJUST, 0);
           }
           // Adjust end year
@@ -4255,13 +4255,13 @@
           else if (Fcast_MGparm_ave_rd(i,4) <= Fcast_MGparm_ave(i,3))
           {
             Fcast_MGparm_ave(i,4) = Fcast_MGparm_ave(i,3) + 1;
-            warnstream << "end year before start year, setting end year to: " << Fcast_MGparm_ave(i,4);
+            warnstream << "Fcast_MGparm_ave end year before start year, setting end year to: " << Fcast_MGparm_ave(i,4);
             write_message(ADJUST, 0);
           }
           else if (Fcast_MGparm_ave_rd(i,4) > endyr)
           {
             Fcast_MGparm_ave(i,4) = endyr;
-            warnstream << "end year exceeds endyr, setting end year to: " << endyr;
+            warnstream << "Fcast_MGparm_ave end year exceeds endyr, setting end year to: " << endyr;
             write_message(ADJUST, 0);
           }
         }

--- a/SS_readdata_330.tpl
+++ b/SS_readdata_330.tpl
@@ -4255,7 +4255,7 @@
           else if (Fcast_MGparm_ave_rd(i,4) < Fcast_MGparm_ave(i,3))
           {
             Fcast_MGparm_ave(i,4) = Fcast_MGparm_ave(i,3);
-            warnstream << "Fcast_MGparm_ave maxyear before start year, setting to: " << Fcast_MGparm_ave(i,4);
+            warnstream << "Fcast_MGparm_ave maxyear before minyear, setting to: " << Fcast_MGparm_ave(i,4);
             write_message(ADJUST, 0);
           }
           if (Fcast_MGparm_ave(i,4) > endyr)

--- a/SS_readdata_330.tpl
+++ b/SS_readdata_330.tpl
@@ -4200,8 +4200,8 @@
     {
       echoinput << "Fcast Control(5)==1, so now read list of MG_type, method (1, 2), start year, end year" << endl
                 << "Terminate with -9999 for MG_type" << endl
-				<< "MG_type: 1=M, 2=growth, 3=wtlen, 4=recr_dist&femfrac, 5=migration, 6=ageerror, 7=catchmult, 8=hermaphroditism" << endl
-        << "Method = 0 (default) means continue time_vary parms; 1 means to use average of derived biology; 2 (future) means average parameter then apply as if time-vary"<<endl;
+                << "MG_type: 1=M, 2=growth, 3=wtlen, 4=recr_dist&femfrac, 5=migration, 6=ageerror, 7=catchmult, 8=hermaphroditism" << endl
+                << "Method = 0 (default) means continue time_vary parms; 1 means to use average of derived biology; 2 (future) means average parameter then apply as if time-vary"<<endl;
       ender = 0;
       do
       {
@@ -4232,16 +4232,24 @@
           {
             Fcast_MGparm_ave(i,3) = styr;
           }
+          else if (Fcast_MGparm_ave_rd(i,3) >= endyr)
+          {
+            Fcast_MGparm_ave(i,3) = endyr - 1;
+          }
 
-          if (Fcast_MGparm_ave_rd(i,4) <= 0)
+          if (Fcast_MGparm_ave_rd(i,4) == -999)
+          {
+            Fcast_MGparm_ave(i,4) = endyr;
+          }
+          else if (Fcast_MGparm_ave_rd(i,4) <= 0)
           {
             Fcast_MGparm_ave(i,4) += endyr;
           }
-          else if (Fcast_MGparm_ave_rd(i,4) < styr)
+          else if (Fcast_MGparm_ave_rd(i,4) <= Fcast_MGparm_ave(i,3))
           {
-            Fcast_MGparm_ave(i,4) += styr;
+            Fcast_MGparm_ave(i,4) = Fcast_MGparm_ave(i,3) + 1;
           }
-          if (Fcast_MGparm_ave_rd(i,4) > endyr)
+          else if (Fcast_MGparm_ave_rd(i,4) > endyr)
           {
             Fcast_MGparm_ave(i,4) = endyr;
           }

--- a/SS_readdata_330.tpl
+++ b/SS_readdata_330.tpl
@@ -4240,6 +4240,8 @@
           else if (Fcast_MGparm_ave_rd(i,3) >= endyr)
           {
             Fcast_MGparm_ave(i,3) = endyr - 1;
+            warnstream << "start year exceeds endyr, setting start year to: " << Fcast_MGparm_ave(i,3);
+            write_message(ADJUST, 0);
           }
           // Adjust end year
           if (Fcast_MGparm_ave_rd(i,4) == -999)
@@ -4253,10 +4255,14 @@
           else if (Fcast_MGparm_ave_rd(i,4) <= Fcast_MGparm_ave(i,3))
           {
             Fcast_MGparm_ave(i,4) = Fcast_MGparm_ave(i,3) + 1;
+            warnstream << "end year before start year, setting end year to: " << Fcast_MGparm_ave(i,4);
+            write_message(ADJUST, 0);
           }
           else if (Fcast_MGparm_ave_rd(i,4) > endyr)
           {
             Fcast_MGparm_ave(i,4) = endyr;
+            warnstream << "end year exceeds endyr, setting end year to: " << endyr;
+            write_message(ADJUST, 0);
           }
         }
       }

--- a/SS_readdata_330.tpl
+++ b/SS_readdata_330.tpl
@@ -4237,10 +4237,10 @@
           {
             Fcast_MGparm_ave(i,3) = styr;
           }
-          else if (Fcast_MGparm_ave_rd(i,3) >= endyr)
+          else if (Fcast_MGparm_ave_rd(i,3) > endyr)
           {
-            Fcast_MGparm_ave(i,3) = endyr - 1;
-            warnstream << "Fcast_MGparm_ave start year exceeds endyr, setting start year to: " << Fcast_MGparm_ave(i,3);
+            Fcast_MGparm_ave(i,3) = endyr;
+            warnstream << "Fcast_MGparm_ave minyear exceeds endyr, setting to: " << endyr;
             write_message(ADJUST, 0);
           }
           // Adjust end year
@@ -4252,16 +4252,16 @@
           {
             Fcast_MGparm_ave(i,4) += endyr;
           }
-          else if (Fcast_MGparm_ave_rd(i,4) <= Fcast_MGparm_ave(i,3))
+          else if (Fcast_MGparm_ave_rd(i,4) < Fcast_MGparm_ave(i,3))
           {
             Fcast_MGparm_ave(i,4) = Fcast_MGparm_ave(i,3) + 1;
-            warnstream << "Fcast_MGparm_ave end year before start year, setting end year to: " << Fcast_MGparm_ave(i,4);
+            warnstream << "Fcast_MGparm_ave maxyear before start year, setting to: " << Fcast_MGparm_ave(i,4);
             write_message(ADJUST, 0);
           }
-          else if (Fcast_MGparm_ave_rd(i,4) > endyr)
+          if (Fcast_MGparm_ave(i,4) > endyr)
           {
             Fcast_MGparm_ave(i,4) = endyr;
-            warnstream << "Fcast_MGparm_ave end year exceeds endyr, setting end year to: " << endyr;
+            warnstream << "Fcast_MGparm_ave maxyear exceeds endyr, setting to: " << endyr;
             write_message(ADJUST, 0);
           }
         }

--- a/SS_readdata_330.tpl
+++ b/SS_readdata_330.tpl
@@ -4224,9 +4224,14 @@
       {
         if (Fcast_MGparm_ave_rd(i,1) > 0)
         {
+          // Adjust start year
           if (Fcast_MGparm_ave_rd(i,3) == -999)
           {
             Fcast_MGparm_ave(i,3) = styr;
+          }
+          else if (Fcast_MGparm_ave_rd(i,3) < 0)
+          {
+            Fcast_MGparm_ave(i,3) = endyr + Fcast_MGparm_ave_rd(i,3);
           }
           else if (Fcast_MGparm_ave_rd(i,3) < styr)
           {
@@ -4236,7 +4241,7 @@
           {
             Fcast_MGparm_ave(i,3) = endyr - 1;
           }
-
+          // Adjust end year
           if (Fcast_MGparm_ave_rd(i,4) == -999)
           {
             Fcast_MGparm_ave(i,4) = endyr;

--- a/SS_readdata_330.tpl
+++ b/SS_readdata_330.tpl
@@ -4254,7 +4254,7 @@
           }
           else if (Fcast_MGparm_ave_rd(i,4) < Fcast_MGparm_ave(i,3))
           {
-            Fcast_MGparm_ave(i,4) = Fcast_MGparm_ave(i,3) + 1;
+            Fcast_MGparm_ave(i,4) = Fcast_MGparm_ave(i,3);
             warnstream << "Fcast_MGparm_ave maxyear before start year, setting to: " << Fcast_MGparm_ave(i,4);
             write_message(ADJUST, 0);
           }


### PR DESCRIPTION
## Concisely describe what has been changed/addressed in the pull request.

Fcast_MGparm_ave could have years set incorrectly. 

This accepts all year values and sets them according to the manual doc or at least to something that will not cause an error.



## What tests have been done? 
year value = -999, <0, <styr, >endyr

### Where are the relevant files?

 [x] No test files are required for this pull request. 

### What tests/review still need to be done?
I don't know of any.

## Is there an input change for users to Stock Synthesis? 

[x] No, there was no input change. 
This is an example of the input files (forecast.ss is the affected file).
[simple_averaging-copy.zip](https://github.com/nmfs-stock-synthesis/stock-synthesis/files/11853263/simple_averaging-copy.zip)

## Additional information (optional).
This input:
 4 1 2001 1066
 3 0 10 -4
 5 1 2004 2500
 1 1 -999 -3
 2 1 1066 4
 8 0 3000 3000
produced this internal data:
 1 1 1971 1998
 2 1 1971 1972
 3 0 1971 1997
 4 1 2000 2001
 5 1 2000 2001
 0 0 0 0
 0 0 0 0
 8 0 2000 2001
and these messages in warning.sso
Warning 1 Adjustment: Fcast_MGparm_ave end year before start year, setting end year to: 1972
Warning 2 Adjustment: Fcast_MGparm_ave start year exceeds endyr, setting start year to: 2000
Warning 3 Adjustment: Fcast_MGparm_ave end year before start year, setting end year to: 2001
Warning 4 Adjustment: Fcast_MGparm_ave start year exceeds endyr, setting start year to: 2000
Warning 5 Adjustment: Fcast_MGparm_ave end year exceeds endyr, setting end year to: 2001
Warning 6 Adjustment: Fcast_MGparm_ave start year exceeds endyr, setting start year to: 2000
Warning 7 Adjustment: Fcast_MGparm_ave end year exceeds endyr, setting end year to: 2001

