### PR TITLE
471 bug gradient issue with forecast recruitment option 3

### DIFF
--- a/SS_global.tpl
+++ b/SS_global.tpl
@@ -211,7 +211,7 @@ GLOBALS_SECTION
     if (exitflag == 1)
     {
       warning.close();
-	    echoinput.close();
+      echoinput.close();
       cout << msg << endl;
       cout << "Also see warning.sso" << endl;
       cout << "Exiting SS3! " << endl;

--- a/SS_readcontrol_330.tpl
+++ b/SS_readcontrol_330.tpl
@@ -2269,6 +2269,12 @@
     write_message (ADJUST, 0);
     recdev_end = retro_yr;
   }
+  if (recdev_end < endyr && (Fcast_Loop_Control(3) == 3 || Fcast_Loop_Control(3) == 4))
+  {
+    warnstream << "Fcast recr option is 3 or 4 and recdev_end: " << recdev_end << " < endyr: " << endyr << " reset ";
+    write_message (ADJUST, 0);
+    recdev_end = endyr;
+  }
   if (recdev_start < (styr - nages))
   {
     warnstream << " recdev_start: " << recdev_start << " < styr-nages: " << styr - nages << " reset ";

--- a/SS_readdata_330.tpl
+++ b/SS_readdata_330.tpl
@@ -4178,22 +4178,10 @@
     }
     else if (Fcast_Loop_Control(3) == 3)
     {
-      if (Fcast_Rec_yr2 != endyr)
-      {
-        warnstream << "Use of forecast recruitment option 3 or 4 requires last year of rec_devs to be end year.";
-        write_message(ADJUST, 1);
-        Fcast_Rec_yr2 = Fcast_yr(6) = endyr;
-      }
       echoinput << " #mean recruitment and recr_dist from years: " << Fcast_Rec_yr1 << " to " << Fcast_Rec_yr2 << endl;
     }
     else if (Fcast_Loop_Control(3) == 4)
     {
-      if (Fcast_Rec_yr2 != endyr)
-      {
-        warnstream << "Use of forecast recruitment option 3 or 4 requires last year of rec_devs to be end year.";
-        write_message(ADJUST, 1);
-        Fcast_Rec_yr2 = Fcast_yr(6) = endyr;
-      }
       echoinput << " #mean recruitment from years: " << Fcast_Rec_yr1 << " to " << Fcast_Rec_yr2 << " recrdist from parameters, or average using control_5" << endl;
     }
     else //  input probably was a -1 from pre 3.30.15, so convert to 0

--- a/SS_readdata_330.tpl
+++ b/SS_readdata_330.tpl
@@ -4180,7 +4180,7 @@
     {
       if (Fcast_Rec_yr2 != endyr)
       {
-        warnstream << "Use of forecast recruitment option 3 or 4 will require last year of rec_devs to be end year.";
+        warnstream << "Use of forecast recruitment option 3 or 4 requires last year of rec_devs to be end year.";
         write_message(ADJUST, 1);
         Fcast_Rec_yr2 = Fcast_yr(6) = endyr;
       }
@@ -4190,7 +4190,7 @@
     {
       if (Fcast_Rec_yr2 != endyr)
       {
-        warnstream << "Use of forecast recruitment option 3 or 4 will require last year of rec_devs to be end year.";
+        warnstream << "Use of forecast recruitment option 3 or 4 requires last year of rec_devs to be end year.";
         write_message(ADJUST, 1);
         Fcast_Rec_yr2 = Fcast_yr(6) = endyr;
       }

--- a/SS_readdata_330.tpl
+++ b/SS_readdata_330.tpl
@@ -4178,10 +4178,22 @@
     }
     else if (Fcast_Loop_Control(3) == 3)
     {
+      if (Fcast_Rec_yr2 < endyr)
+      {
+        warnstream << "Use of forecast recruitment option 3 or 4 will require last year of rec_devs to be end year.";
+        write_message(ADJUST, 0);
+        Fcast_Rec_yr2 = Fcast_yr(6) = endyr;
+      }
       echoinput << " #mean recruitment and recr_dist from years: " << Fcast_Rec_yr1 << " to " << Fcast_Rec_yr2 << endl;
     }
     else if (Fcast_Loop_Control(3) == 4)
     {
+      if (Fcast_Rec_yr2 < endyr)
+      {
+        warnstream << "Use of forecast recruitment option 3 or 4 will require last year of rec_devs to be end year.";
+        write_message(ADJUST, 0);
+        Fcast_Rec_yr2 = Fcast_yr(6) = endyr;
+      }
       echoinput << " #mean recruitment from years: " << Fcast_Rec_yr1 << " to " << Fcast_Rec_yr2 << " recrdist from parameters, or average using control_5" << endl;
     }
     else //  input probably was a -1 from pre 3.30.15, so convert to 0

--- a/SS_readdata_330.tpl
+++ b/SS_readdata_330.tpl
@@ -4178,20 +4178,20 @@
     }
     else if (Fcast_Loop_Control(3) == 3)
     {
-      if (Fcast_Rec_yr2 < endyr)
+      if (Fcast_Rec_yr2 != endyr)
       {
         warnstream << "Use of forecast recruitment option 3 or 4 will require last year of rec_devs to be end year.";
-        write_message(ADJUST, 0);
+        write_message(ADJUST, 1);
         Fcast_Rec_yr2 = Fcast_yr(6) = endyr;
       }
       echoinput << " #mean recruitment and recr_dist from years: " << Fcast_Rec_yr1 << " to " << Fcast_Rec_yr2 << endl;
     }
     else if (Fcast_Loop_Control(3) == 4)
     {
-      if (Fcast_Rec_yr2 < endyr)
+      if (Fcast_Rec_yr2 != endyr)
       {
         warnstream << "Use of forecast recruitment option 3 or 4 will require last year of rec_devs to be end year.";
-        write_message(ADJUST, 0);
+        write_message(ADJUST, 1);
         Fcast_Rec_yr2 = Fcast_yr(6) = endyr;
       }
       echoinput << " #mean recruitment from years: " << Fcast_Rec_yr1 << " to " << Fcast_Rec_yr2 << " recrdist from parameters, or average using control_5" << endl;


### PR DESCRIPTION
<!-- General instructions -->
<!--
* Please read the html comment under each heading and follow the instructions.
* For smaller changes, feel free to skip sections flagged as "optional".
* Before opening the pull request (PR), make sure all the GitHub actions are
  passing on the remote feature branch.
* Make sure this PR has an informative title rather than the default text.
* Lastly, before closing the PR, **please make sure that all comments/discussion in this PR that are related to an issue are placed in the summary of that issue**.
-->

## Concisely describe what has been changed/addressed in the pull request.
Added a Warning: Adjustment when forecast recruitment option is 3 or 4 and end_recruits year is not equal to endyr.

* Resolves issue #471

## What tests have been done? 
### Where are the relevant files?

[x] Test files are in the issue. 

### What tests/review still need to be done?
<!-- If no additional tests are needed, please put None.-->
<!-- Provide information on who/when for uncompleted tasks -->

## Is there an input change for users to Stock Synthesis? 
<!-- Uncomment the option below that best fits the situation. -->
<!-- If needed, uncomment the code block and replace the text. -->

<!-- - [x] The input change is in the related issue(s). -->
<!-- - [x] There is no issue related to this pull request so the input change is below. -->
[x] No, there was no input change. 


## Additional information (optional).
<!--- Any additional information goes here. -->
