### PR TITLE
correct index usage in expval

### DIFF
--- a/SS_expval.tpl
+++ b/SS_expval.tpl
@@ -262,24 +262,26 @@ FUNCTION void Get_expected_values(const int y, const int t);
                     //  should sum over all g, but the g is already subsummed when agetemp is created by gender
                     {
                       vbio = 0.0;
+//                      warning<<f<<" "<<y<<" "<<s<<" "<<t<<" y_wts "<<Wt_Age_t(y, f, 1)<<endl;
+//                      warning<<f<<" "<<y<<" "<<s<<" "<<t<<" t_wts "<<Wt_Age_t(t, f, 1)<<endl;
                       if (Do_Retain(f) == 0) //  all retained
                       {
                         for (a = 0; a <= nages; a++)
-                          vbio += Wt_Age_t(y, f, 1, a) * agetemp(a);
+                          vbio += Wt_Age_t(t, f, 1, a) * agetemp(a);
                         if (gender == 2)
                         {
                           for (a = 0; a <= nages; a++)
-                            vbio += Wt_Age_t(y, f, 2, a) * agetemp(a + nages + 1);
+                            vbio += Wt_Age_t(t, f, 2, a) * agetemp(a + nages + 1);
                         }
                       }
                       else
                       {
                         for (a = 0; a <= nages; a++)
-                          vbio += Wt_Age_t(y, f, 1, a) * exp_truea_ret(a);
+                          vbio += Wt_Age_t(t, f, 1, a) * exp_truea_ret(a);
                         if (gender == 2)
                         {
                           for (a = 0; a <= nages; a++)
-                            vbio += Wt_Age_t(y, f, 2, a) * exp_truea_ret(a + nages + 1);
+                            vbio += Wt_Age_t(t, f, 2, a) * exp_truea_ret(a + nages + 1);
                         }
                       }
                     }


### PR DESCRIPTION
<!-- General instructions -->
<!--
* Please read the html comment under each heading and follow the instructions.
* For smaller changes, feel free to skip sections flagged as "optional".
* Before opening the pull request (PR), make sure all the GitHub actions are
  passing on the remote feature branch.
* Make sure this PR has an informative title rather than the default text.
* Lastly, before closing the PR, **please make sure that all comments/discussion in this PR that are related to an issue are placed in the summary of that issue**.
-->

## Concisely describe what has been changed/addressed in the pull request.
<!--- In less than 20 words describe this PR and link related issues.-->
<!--- A summary is important if there is no issue related to the PR, otherwise the summary should be in the issue.-->


<!-- Link related issue(s) using a bulleted list. -->
<!-- Remove the following bullet if no issues are linked to this PR. -->
* Resolves issue #484 

## What tests have been done? 
### Where are the relevant files?
<!-- Uncomment the option below that best fits the situation and upload the necessary files to the correct location, preferably the associated issue(s). -->
A temporary version of vendance seasonal wtatage model was created and a temporary write statement was put into expval.  This verified that the error existed.  No other usage of Wt_Age_t(y, f) exists in the code.  All are now Wt_Age_t(t, f)
<!-- - [] Test files are in the issue. -->
<!-- - [] There is no issue related to this pull request so the files are attached below. -->
<!-- - [X] No test files are required for this pull request. -->

### What tests/review still need to be done?
<!-- If no additional tests are needed, please put None.-->
<!-- Provide information on who/when for uncompleted tasks -->
None
## Is there an input change for users to Stock Synthesis? 
<!-- Uncomment the option below that best fits the situation. -->
<!-- If needed, uncomment the code block and replace the text. -->

<!-- - [x] The input change is in the related issue(s). -->
<!-- - [x] There is no issue related to this pull request so the input change is below. -->
<!-- - [x] No, there was no input change. -->

<!---
```
If there is no issue related to this PR, replace this text with your example stock synthesis input.
```
-->

## Additional information (optional).
<!--- Any additional information goes here. -->
