### PR TITLE
repair_check_on_Nparms_in_parfile

### DIFF
--- a/SS_param.tpl
+++ b/SS_param.tpl
@@ -480,7 +480,7 @@ PARAMETER_SECTION
   init_bounded_vector_vector parm_dev(1,N_parm_dev,parm_dev_minyr,parm_dev_maxyr,-10,10,parm_dev_PH)
   matrix parm_dev_rwalk(1,N_parm_dev,parm_dev_minyr,parm_dev_maxyr);
 
-  init_bounded_number checksum999(998,1000,-999)  //  set value to 999 to check reading of ss.par
+  init_bounded_number checksum999(998,1000,-1)  //  value must be 999 to check reading of ss.par
   vector timevary_parm(1,timevary_parm_cnt);  //  holds the link parameters; in SS_timevaryparm these are set to actual parms in MGparms, SRparms, Qparms, selparms
   matrix parm_timevary(1,timevary_cnt,styr-1,YrMax);  //  time series of adjusted parm values for block and trend
 

--- a/SS_prelim.tpl
+++ b/SS_prelim.tpl
@@ -824,6 +824,16 @@
       }
       echoinput << " Tag_parms read from ctl " << TG_parm << endl;
     }
+    checksum999 = 999.;
+  }
+  else
+  {
+        echoinput << "checksum from par file "<<checksum999<<endl;
+    if (checksum999 != 999.)
+    {
+          warnstream << "error on ss.par read; final value was not 999; total number parms changed  " << checksum999;
+          write_message (FATAL, 1);
+    }
   }
 
   //  SS_Label_Info_6.5 #Check parameter bounds and do jitter


### PR DESCRIPTION
The checksum value at end of ss.par was intended to provide a check when the number of parameters in the model changed.  This check is now added to ss_prelim.  SS3 will exit if value of checksum, which is not actually a checksum, is not equal to 999.

No issue is linked
No input change for the user.  The 999 value is created when a model is read from the control file.