### PR TITLE
[Bug]: fix bootstrap sample size issue for size frequency data

### DIFF
--- a/SS_write_ssnew.tpl
+++ b/SS_write_ssnew.tpl
@@ -1344,7 +1344,9 @@ FUNCTION void write_nudata()
         for (iobs = 1; iobs <= SzFreq_totobs; iobs++)
         {
           f = SzFreq_obs1(iobs, 1);  //  sizefreq method
+          // maximum sample size for bootstrapping is 50000
           double Nsamp_dat = 50000;
+          // set sample size
           if (SzFreq_obs1(iobs, 7) < Nsamp_dat)
           Nsamp_dat = SzFreq_obs1(iobs, 7);
           SzFreq_newdat.initialize();
@@ -1376,10 +1378,12 @@ FUNCTION void write_nudata()
                   break;
                 }
               }
-
+          // get probabilities for this observation
           temp_probs3(1, SzFreq_Setup2(iobs)) = value(SzFreq_exp(iobs));
+          // generate a vector of multinomial random variables (bin numbers)
           temp_mult.fill_multinomial(radm, temp_probs3(1, SzFreq_Setup2(iobs))); // create multinomial draws with prob = expected values
-          for (compindex = 1; compindex <= j; compindex++) // cumulate the multinomial draws by index in the new data
+          // increment the new data vector by bin number
+          for (compindex = 1; compindex <= Nsamp_dat; compindex++) // cumulate the multinomial draws by index in the new data
           {
             SzFreq_newdat(temp_mult(compindex)) += 1.0;
           }


### PR DESCRIPTION
## Concisely describe what has been changed/addressed in the pull request.
<!--- In less than 20 words describe this PR and link related issues.-->
<!--- A summary is important if there is no issue related to the PR, otherwise the summary should be in the issue.-->
Fixes problem with number of generalized size comp bootstrap samples not matching the sample size.

<!-- Link related issue(s) using a bulleted list. -->
<!-- Remove the following bullet if no issues are linked to this PR. -->
* Resolves #733 

## What tests have been done? 
### Where are the relevant files?
Before the change, the sum of the bootstrap samples in this model https://github.com/nmfs-ost/ss3-test-models/tree/main/models/Simple_with_DM_sizefreq was 50 for each observation. After the change, it matches in sample size of 125.

<!-- - [x] Test files are in the issue. -->
<!-- - [x] There is no issue related to this pull request so the files are attached below. -->
<!-- - [x] No test files are required for this pull request. -->

### What tests/review still need to be done?
<!-- If no additional tests are needed, please put None.-->
<!-- Provide information on who/when for uncompleted tasks -->
@Rick-Methot-NOAA look over the changes for correctness.

## Is there an input change for users to Stock Synthesis? 
<!-- Uncomment the option below that best fits the situation. -->
<!-- If needed, uncomment the code block and replace the text. -->

<!-- - [x] The input change is in the related issue(s). -->
<!-- - [x] There is no issue related to this pull request so the input change is below. -->
[x] No, there was no input change.

<!---
```
If there is no issue related to this PR, replace this text with your example stock synthesis input.
```
-->

