### PR TITLE
[Bug]: fix timevary_SRparm for styr-1 start

### DIFF
--- a/SS_readcontrol_330.tpl
+++ b/SS_readcontrol_330.tpl
@@ -2181,7 +2181,10 @@
           }
           else if(SRflag == 1)
           {
-            timevary_SRparm(y) = 2;  //  flag to carry forward current SRR info
+            if (y > styr)
+            {timevary_SRparm(y) = 2;}  //  flag to carry forward current SRR info
+            else
+            {timevary_SRparm(y) = 1;}  //  keep at 1
           }
         }
       }
@@ -2195,6 +2198,7 @@
     N_SRparm3 += (timevary_parm_SR_last - timevary_SRparm_first + 1);
     echoinput << " SR timevary_parm_cnt start and end " << timevary_SRparm_first << " " << timevary_parm_SR_last << endl;
     echoinput << "link to timevary parms:  " << SRparm_timevary << endl;
+    echoinput << "timevary SRparms:  " << timevary_SRparm << endl;
   }
   echoinput << "SR_Npar and N_SRparm2 and N_SRparm3:  " << N_SRparm(SR_fxn) << " " << N_SRparm2 << " " << N_SRparm3 << endl;
   // clang-format off


### PR DESCRIPTION
<!-- General instructions -->
<!--
* Please read the html comment under each heading and follow the instructions.
* For smaller changes, feel free to skip sections flagged as "optional".
* Before opening the pull request (PR), make sure all the GitHub actions are
  passing on the remote feature branch.
* Make sure this PR has an informative title rather than the default text.
* Lastly, before closing the PR, **please make sure that all comments/discussion in this PR that are related to an issue are placed in the summary of that issue**.
-->

## Concisely describe what has been changed/addressed in the pull request.
<!--- In less than 20 words describe this PR and link related issues.-->
<!--- A summary is important if there is no issue related to the PR, otherwise the summary should be in the issue.-->
A user noted that timevary ln(R0) was not working correctly if the block started in styr-1, rather than starting during the time series.  This is fixed by a small change to the creation of timevary_SRparm(y) in readcontrol

<!-- Link related issue(s) using a bulleted list. -->
<!-- Remove the following bullet if no issues are linked to this PR. -->
* Resolves #
* no issue

## What tests have been done? 
Rick tested using an example from Andre with a blovk on ln(R0) starting in styr-1

### Where are the relevant files?
<!-- Uncomment the option below that best fits the situation and upload the necessary files to the correct location, preferably the associated issue(s). -->

<!-- - [x] Test files are in the issue. -->
<!-- - [x] There is no issue related to this pull request so the files are attached below. -->
<-- - [x] No test files are required for this pull request. -->

### What tests/review still need to be done?
<!-- If no additional tests are needed, please put None.-->
<!-- Provide information on who/when for uncompleted tasks -->
Andre will be testing
## Is there an input change for users to Stock Synthesis? 
<!-- Uncomment the option below that best fits the situation. -->
<!-- If needed, uncomment the code block and replace the text. -->

<!-- - [x] The input change is in the related issue(s). -->
<!-- - [x] There is no issue related to this pull request so the input change is below. -->
<-- - [x] No, there was no input change. -->

<!---
```
If there is no issue related to this PR, replace this text with your example stock synthesis input.
```
-->

## Additional information (optional).
<!--- Any additional information goes here. -->
