### PR TITLE
add endl, remove extra spaces for consistent Report.sso format

### DIFF
--- a/SS_write_report.tpl
+++ b/SS_write_report.tpl
@@ -1813,10 +1813,10 @@ FUNCTION void write_bigoutput()
     }
     SS2out << "#" << endl;
     if (SRparm_timevary(N_SRparm2 - 1) > 0) //  timevary regime exists
-      {SS2out << " #_Regime_used_to_offset_from_SRR";}
+      {SS2out << "#_Regime_used_to_offset_from_SRR" << endl;}
     SS2out << timevary_bio_4SRR << " # timevary_bio_4SRR  #_Compatibility_flag_for_legacy_(0)_vs_improved_(1)_impact_of_timevary_biology_on_benchmark_SRR_calcs" << endl;
     if( timevary_MG_firstyr == YrMax)
-    { SS2out << " #_No_timevary_MGparm" << endl; }
+    { SS2out << "#_No_timevary_MGparm" << endl; }
     else
     { SS2out << timevary_MG_firstyr << " #_first year_timevary_MGparm_(or_any_year_EWAA) " << endl; }
 


### PR DESCRIPTION
## Concisely describe what has been changed/addressed in the pull request.
Missing linebreak was leading to output where the 0/1 value of the compatibility flag was part of the previous comment ending with "SRR":

```
#
 #_Regime_used_to_offset_from_SRR0 # timevary_bio_4SRR  #_Compatibility_flag_for_legacy_(0)_vs_improved_(1)_impact_of_timevary_biology_on_benchmark_SRR_calcs
 #_No_timevary_MGparm
#
```
After the fix it should look like
```
#
#_Regime_used_to_offset_from_SRR
0 # timevary_bio_4SRR  #_Compatibility_flag_for_legacy_(0)_vs_improved_(1)_impact_of_timevary_biology_on_benchmark_SRR_calcs
#_No_timevary_MGparm
#
```

## What tests have been done? 
Ran SS3 with model shared by user, which I will email to nmfs.stock.synthesis@noaa.gov.

### What tests/review still need to be done?
None.

## Is there an input change for users to Stock Synthesis? 
[x] No, there was no input change.
