### PR TITLE
repair gparm output to adjust for -VBK change

### DIFF
--- a/SS_biofxn.tpl
+++ b/SS_biofxn.tpl
@@ -1988,13 +1988,13 @@ FUNCTION void get_saveGparm()
         save_G_parm(save_gparm, 7) = value(Lmax_temp(gp));
         if (do_ageK == 1)
         {
-          save_G_parm(save_gparm, 8) = value(-VBK(gp, nages) * VBK_seas(0));
-          save_G_parm(save_gparm, 9) = value(-log(L_inf(gp) / (L_inf(gp) - Lmin(gp))) / (-VBK(gp, nages) * VBK_seas(0)) + AFIX + azero_G(g));
+          save_G_parm(save_gparm, 8) = value(VBK(gp, nages) * VBK_seas(0));
+          save_G_parm(save_gparm, 9) = value(-log(L_inf(gp) / (L_inf(gp) - Lmin(gp))) / (VBK(gp, nages) * VBK_seas(0)) + AFIX + azero_G(g));
         }
         else
         {
-          save_G_parm(save_gparm, 8) = value(-VBK(gp, 0) * VBK_seas(0));
-          save_G_parm(save_gparm, 9) = value(-log(L_inf(gp) / (L_inf(gp) - Lmin(gp))) / (-VBK(gp, 0) * VBK_seas(0)) + AFIX + azero_G(g));
+          save_G_parm(save_gparm, 8) = value(VBK(gp, 0) * VBK_seas(0));
+          save_G_parm(save_gparm, 9) = value(-log(L_inf(gp) / (L_inf(gp) - Lmin(gp))) / (VBK(gp, 0) * VBK_seas(0)) + AFIX + azero_G(g));
         }
 
         save_G_parm(save_gparm, 10) = value(L_inf(gp));


### PR DESCRIPTION
<!-- General instructions -->
<!--
* Please read the html comment under each heading and follow the instructions.
* For smaller changes, feel free to skip sections flagged as "optional".
* Before opening the pull request (PR), make sure all the GitHub actions are
  passing on the remote feature branch.
* Make sure this PR has an informative title rather than the default text.
* Lastly, before closing the PR, **please make sure that all comments/discussion in this PR that are related to an issue are placed in the summary of that issue**.
-->

## Concisely describe what has been changed/addressed in the pull request.
<!--- In less than 20 words describe this PR and link related issues.-->
<!--- A summary is important if there is no issue related to the PR, otherwise the summary should be in the issue.-->
The restores correct output of VBK and t0 to the growth_parameter output.  Incorrect output was occurring due to the change of sign to VBK in 3.30.25.

<!-- Link related issue(s) using a bulleted list. -->
<!-- Remove the following bullet if no issues are linked to this PR. -->
* Resolves #763

## What tests have been done? 
eyeball the output
### Where are the relevant files?
<!-- Uncomment the option below that best fits the situation and upload the necessary files to the correct location, preferably the associated issue(s). -->

<!-- - [x] Test files are in the issue. -->
<!-- - [x] There is no issue related to this pull request so the files are attached below. -->
<-- - [x] No test files are required for this pull request. -->

### What tests/review still need to be done?
<!-- If no additional tests are needed, please put None.-->
<!-- Provide information on who/when for uncompleted tasks -->
none
## Is there an input change for users to Stock Synthesis? 
<!-- Uncomment the option below that best fits the situation. -->
<!-- If needed, uncomment the code block and replace the text. -->

<!-- - [x] The input change is in the related issue(s). -->
<!-- - [x] There is no issue related to this pull request so the input change is below. -->
<!-- - [x] No, there was no input change. -->

<!---
```
If there is no issue related to this PR, replace this text with your example stock synthesis input.
```
-->

## Additional information (optional).
<!--- Any additional information goes here. -->
